### PR TITLE
Change type for a callable request

### DIFF
--- a/google/genai/pagers.py
+++ b/google/genai/pagers.py
@@ -33,7 +33,7 @@ class _BasePager(Generic[T]):
   def __init__(
       self,
       name: PagedItem,
-      request: Callable[Any, Any],
+      request: Callable[[Any], Any],
       response: Any,
       config: Any,
   ):


### PR DESCRIPTION
raise TypeError(f"Callable[args, result]: args must be a list."
TypeError: Callable[args, result]: args must be a list. Got typing.Any