### PR TITLE
fix: make the SSE parser properly ignore non-data chunks

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -192,7 +192,7 @@ class HttpResponse:
             chunk = chunk.decode('utf-8')
           if chunk.startswith('data: '):
             chunk = chunk[len('data: ') :]
-          yield json.loads(chunk)
+            yield json.loads(chunk)
 
   async def async_segments(self) -> AsyncIterator[Any]:
     if isinstance(self.response_stream, list):
@@ -214,7 +214,7 @@ class HttpResponse:
               chunk = chunk.decode('utf-8')
             if chunk.startswith('data: '):
               chunk = chunk[len('data: ') :]
-            yield json.loads(chunk)
+              yield json.loads(chunk)
       else:
         raise ValueError(
             'Error parsing streaming response.'


### PR DESCRIPTION
As per https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#event_stream_format and https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#examples, the actual SSE stream can have so-called "comments" that do not have a field name and just have whatever comment after the colon. Any proper SSE parser should ignore those and not try to parse them. 

In the case of python-genai, this is an issue when using a different `base_url` in `http_options` for a separate proxy to the Gemini API which might add extra things in the SSE stream (for example, keepalive like `: this is a keep-alive`). As far as I know this should be a very safe change because the official API only cares about the "data" chunks in any way (if there were any other chunks with prefixes, the json parsing would fail anyway).  