### PR TITLE
Support Json-Schema beside OPENAPI Schema

### DIFF
--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -1321,10 +1321,10 @@ def test_pydantic_model_in_union_type():
 
 def test_pydantic_model_with_default_value():
   class MySimplePydanticModel(pydantic.BaseModel):
-    a_simple: Optional[int]
-    b_simple: Optional[str]
+    a_simple: typing.Optional[int] = 1
+    b_simple: typing.Optional[str] = 'a'
 
-  mySimplePydanticModel = MySimplePydanticModel(a_simple=1, b_simple='a')
+  mySimplePydanticModel = MySimplePydanticModel()
 
   def func_under_test(a: MySimplePydanticModel = mySimplePydanticModel):
     """test pydantic model with default value."""
@@ -1337,7 +1337,7 @@ def test_pydantic_model_with_default_value():
           type='OBJECT',
           properties={
               'a': types.Schema(
-                  default=MySimplePydanticModel(a_simple=1, b_simple='a'),
+                  default=mySimplePydanticModel,
                   type='OBJECT',
                   properties={
                       'a_simple': types.Schema(
@@ -1363,7 +1363,7 @@ def test_pydantic_model_with_default_value():
   actual_schema_vertex = types.FunctionDeclaration.from_callable(
       client=vertex_client, callable=func_under_test
   )
-
+  
   assert actual_schema_vertex == expected_schema_vertex
 
 


### PR DESCRIPTION
feat(types): add JSON Schema support to the types module

This PR introduces JSON Schema support to the types module, including compatibility 
with OpenAPI Schema conversions. Key changes include:

- **New Features**:
  - Added JSON Schema attributes and aligned OPENAPI attributes with the JSON Schema standard.
  - Implemented field aliases for JSON Schema compatibility.
  - Added validators to handle JSON Schema to OpenAPI Schema conversion.

- **Deprecations**:
  - Added warnings for deprecated attributes to guide users toward the new standard.

- **Testing**:
  - Added unit tests to validate JSON Schema functionality and conversions.

This change is for supporting users with JSON-based schema while maintaining backward compatibility with existing OpenAPI usage.

The changes haven't been finalized because I need support in changing all the past tests related to types to accept the output as JSON Schema.

Fixes Issue #550 .