### PR TITLE
fix: Remove uniqueItems from set schemas to fix validation errors

### DIFF
--- a/google/genai/_transformers.py
+++ b/google/genai/_transformers.py
@@ -704,6 +704,13 @@ def process_schema(
 
   handle_null_fields(schema)
 
+  # Fix for Issue #554: Pydantic v2 generates uniqueItems=True for sets,
+  # which is valid JSON Schema but causes issues downstream. Remove it.
+  # We check for both upper and lower case 'array' just in case.
+  schema_type_val = schema.get('type')
+  if schema_type_val == 'ARRAY' or schema_type_val == 'array':
+      schema.pop('uniqueItems', None)
+
   # After removing null fields, Optional fields with only one possible type
   # will have a $ref key that needs to be flattened
   # For example: {'default': None, 'description': 'Name of the person', 'nullable': True, '$ref': '#/$defs/TestPerson'}


### PR DESCRIPTION
# Fix: Support set types in response_schema (Issue #554 )

## Description
Fixes validation error when using Pydantic models with `set` fields in `response_schema`.

## Issue
Pydantic v2 adds `uniqueItems=True` to JSON schemas for sets, but this property isn't supported by the internal `Schema` class.

## Fix
Modified `process_schema` in `_transformers.py` to remove `uniqueItems` from array schemas during transformation.

## Testing
Added test with `set[int]` field that verifies schema transformation works correctly without the `uniqueItems` property.
