### PR TITLE
feat: support using the passed credentials in AsyncLive::connect

### DIFF
--- a/google/genai/live.py
+++ b/google/genai/live.py
@@ -892,15 +892,18 @@ class AsyncLive(_api_module.BaseModule):
 
       request = json.dumps(request_dict)
     else:
-      # Get bearer token through Application Default Credentials.
-      creds, _ = google.auth.default(  # type: ignore[no-untyped-call]
+      if not self._api_client._credentials:
+        # Get bearer token through Application Default Credentials.
+        creds, _ = google.auth.default(  # type: ignore[no-untyped-call]
           scopes=['https://www.googleapis.com/auth/cloud-platform']
-      )
-
+        )
+      else:
+        creds = self._api_client._credentials
       # creds.valid is False, and creds.token is None
       # Need to refresh credentials to populate those
-      auth_req = google.auth.transport.requests.Request()  # type: ignore[no-untyped-call]
-      creds.refresh(auth_req)
+      if not (creds.token and creds.valid):
+        auth_req = google.auth.transport.requests.Request()  # type: ignore[no-untyped-call]
+        creds.refresh(auth_req)
       bearer_token = creds.token
       headers = self._api_client._http_options.headers
       if headers is not None:


### PR DESCRIPTION
## Description
Reference Issue: #717 

Added functionality to `google/genai/live` `AsyncLive::connect` method:

When a credentials object is provided during client creation (`genai.Client`), that credential token will be used. If no credentials object is provided (i.e. `None`), the flow retrieves the bearer token from Application Default Credentials.

## How Has This Been Tested?
I ran pytests for the live api under `google/genai/tests/live`

## Checklist
- [x] My code follows the project's style structure
- [x] I have performed a self-review of my code
- [x] I have added tests that prove the feature works