### PR TITLE
feat: Make websockets an optional dependency for live module

### DIFF
--- a/google/genai/live.py
+++ b/google/genai/live.py
@@ -25,7 +25,24 @@ import warnings
 
 import google.auth
 import pydantic
-from websockets import ConnectionClosed
+
+# MODIFIED: Wrap all websockets imports in a single try-except ImportError block
+try:
+    from websockets import ConnectionClosed
+
+    # Original try-except block for different websockets APIs/versions is preserved inside
+    try:
+      from websockets.asyncio.client import ClientConnection
+      from websockets.asyncio.client import connect
+    except ModuleNotFoundError:
+      # This try/except is for TAP, mypy complains about it which is why we have the type: ignore
+      from websockets.client import ClientConnection  # type: ignore
+      from websockets.client import connect  # type: ignore
+except ImportError:
+    raise ImportError(
+        "The `websockets` library is required for live, interactive sessions. "
+        "Please install it using `pip install google-genai[live]`."
+    )
 
 from . import _api_module
 from . import _common
@@ -39,14 +56,6 @@ from . import _live_converters as live_converters
 from .models import _Content_to_mldev
 from .models import _Content_to_vertex
 
-
-try:
-  from websockets.asyncio.client import ClientConnection
-  from websockets.asyncio.client import connect
-except ModuleNotFoundError:
-  # This try/except is for TAP, mypy complains about it which is why we have the type: ignore
-  from websockets.client import ClientConnection  # type: ignore
-  from websockets.client import connect  # type: ignore
 
 logger = logging.getLogger('google_genai.live')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,11 @@ dependencies = [
     "httpx>=0.28.1, <1.0.0",
     "pydantic>=2.0.0, <3.0.0",
     "requests>=2.28.1, <3.0.0",
-    "websockets>=13.0.0, <15.1.0",
     "typing-extensions>=4.11.0, <5.0.0",
 ]
+
+[project.optional-dependencies]
+live = ["websockets>=13.0.0, <15.1.0"]
 
 [project.urls]
 Homepage = "https://github.com/googleapis/python-genai"


### PR DESCRIPTION
Makes the `websockets` library an optional dependency, only required for the `.live` module.

Changes addressed :
- Moving `websockets` to `project.optional-dependencies.live` in `pyproject.toml`.
- Updating `google/genai/live.py` to raise an informative `ImportError` if `websockets` is not installed when the `live` module is imported, guiding users to install it via `pip install google-genai[live]`.

Fixes issue #765