### PR TITLE
Simplify file parameter type hint

### DIFF
--- a/google/genai/files.py
+++ b/google/genai/files.py
@@ -597,7 +597,7 @@ class Files(_api_module.BaseModule):
   def upload(
       self,
       *,
-      file: Union[str, pathlib.Path, os.PathLike[str], io.IOBase],
+      file: str | os.PathLike[str] | io.IOBase,
       config: Optional[types.UploadFileConfigOrDict] = None,
   ) -> types.File:
     """Calls the API to upload a file using a supported file service.
@@ -1069,7 +1069,7 @@ class AsyncFiles(_api_module.BaseModule):
   async def upload(
       self,
       *,
-      file: Union[str, pathlib.Path, os.PathLike[str], io.IOBase],
+      file: str | os.PathLike[str] | io.IOBase,
       config: Optional[types.UploadFileConfigOrDict] = None,
   ) -> types.File:
     """Calls the API to upload a file asynchronously using a supported file service.


### PR DESCRIPTION
This PR updates a type hint in google/genai/files.py:
```python
file: Union[str, pathlib.Path, os.PathLike[str], io.IOBase]
```
to:
```python
file: str | os.PathLike[str] | io.IOBase
```
- This removes the redundant pathlib.Path, which is already a subclass of os.PathLike[str].
- Also switches to the modern | union syntax per PEP 604, assuming Python 3.10+ support.