### PR TITLE
fix: finally close the aiohttp client in _async_request_once

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -1149,9 +1149,11 @@ class BaseApiClient:
               timeout=aiohttp.ClientTimeout(connect=http_request.timeout),
               **self._async_client_session_request_args,
           )
+        finally:
+          await session.close()
 
         await errors.APIError.raise_for_async_response(response)
-        return HttpResponse(response.headers, response, session=session)
+        return HttpResponse(response.headers, response)
       else:
         # aiohttp is not available. Fall back to httpx.
         httpx_request = self._async_httpx_client.build_request(


### PR DESCRIPTION
In the current implementation, the `aiohttp` client session is not reliably closed in scenarios such as when an `aiohttp.ClientError` is raised. This update ensures that the client session is properly closed in all cases, effectively addressing the issue of unclosed client connections.

Edit: I have just signed CLA