### PR TITLE
Bugfix: Add missing fields to the model types

### DIFF
--- a/google/genai/models.py
+++ b/google/genai/models.py
@@ -3398,6 +3398,37 @@ def _Model_from_mldev(
         getv(from_object, ['supportedGenerationMethods']),
     )
 
+  if getv(from_object, ['temperature']) is not None:
+    setv(
+        to_object,
+        ['temperature'],
+        getv(from_object, ['temperature']),
+    )
+  if getv(from_object, ['maxTemperature']) is not None:
+    setv(
+        to_object,
+        ['max_temperature'],
+        getv(from_object, ['maxTemperature']),
+  )
+  if getv(from_object, ['thinking']) is not None:
+    setv(
+        to_object,
+        ['thinking'],
+        getv(from_object, ['thinking']),
+    )
+  if getv(from_object, ['topP']) is not None:
+    setv(
+        to_object,
+        ['top_p'],
+        getv(from_object, ['topP']),
+    )
+  if getv(from_object, ['topK']) is not None:
+    setv(
+        to_object,
+        ['top_k'],
+        getv(from_object, ['topK']),
+    )
+
   return to_object
 
 

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -7634,6 +7634,31 @@ class Model(_common.BaseModel):
   checkpoints: Optional[list[Checkpoint]] = Field(
       default=None, description="""The checkpoints of the model."""
   )
+  temperature: Optional[float] = Field(
+      default=None,
+      description="""Controls the randomness of the output.
+      """,
+  )
+  max_temperature: Optional[float] = Field(
+      default=None,
+      description="""The maximum temperature this model can use.
+      """,
+  )
+  thinking: Optional[bool] = Field(
+      default=None,
+      description="""Whether the model supports thinking.
+      """,
+  )
+  top_p: Optional[float] = Field(
+      default=None,
+      description="""Nucleus sampling considers the smallest set of tokens whose probability sum is at least topP.
+      """,
+  )
+  top_k: Optional[int] = Field(
+      default=None,
+      description="""Top-k sampling considers the set of topK most probable tokens.
+      """,
+  )
 
 
 class ModelDict(TypedDict, total=False):
@@ -7680,6 +7705,25 @@ class ModelDict(TypedDict, total=False):
   checkpoints: Optional[list[CheckpointDict]]
   """The checkpoints of the model."""
 
+  temperature: Optional[float]
+  """Controls the randomness of the output.
+      """
+
+  max_temperature: Optional[float]
+  """The maximum temperature this model can use.
+      """
+
+  thinking: Optional[bool]
+  """Whether the model supports thinking.
+      """
+
+  top_p: Optional[float]
+  """Nucleus sampling considers the smallest set of tokens whose probability sum is at least topP.
+      """
+
+  top_k: Optional[int]
+  """Top-k sampling considers the set of topK most probable tokens.
+      """
 
 ModelOrDict = Union[Model, ModelDict]
 


### PR DESCRIPTION
- Added missing fields to the model dict that will fix the model and model list APIs
- The fields added includes:
    - temperature
    - max_temperature
    - thinking
    - top_p
    - top_k

These fields are included in the [shell/raw api](https://ai.google.dev/api/models#models_get-SHELL) version, however it seems to be missing the python sdk, so decided to add it.
With the latest release of the `python-genai` sdk
<img width="1597" height="693" alt="Screenshot from 2025-09-20 17-49-42" src="https://github.com/user-attachments/assets/33dba719-cc84-4a88-970d-b0d6b3af789b" />

With the made fixes:
<img width="635" height="693" alt="Screenshot from 2025-09-20 18-02-56" src="https://github.com/user-attachments/assets/96a93b3a-808d-4058-a919-4777995ced27" />


Let me know if the default values are to be added or is it fine to keep it optional, I just followed the convention and the standard from the existing fields.

Thanks.

