### PR TITLE
fix: add IMAGE_PROHIBITED_CONTENT finish reason

### DIFF
--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -277,6 +277,8 @@ class FinishReason(_common.CaseInSensitiveEnum):
   """Token generation stopped because the content contains forbidden terms."""
   PROHIBITED_CONTENT = 'PROHIBITED_CONTENT'
   """Token generation stopped for potentially containing prohibited content."""
+  IMAGE_PROHIBITED_CONTENT = 'IMAGE_PROHIBITED_CONTENT'
+  """Token generation stopped for potentially containing prohibited content."""
   SPII = 'SPII'
   """Token generation stopped because the content potentially contains Sensitive Personally Identifiable Information (SPII)."""
   MALFORMED_FUNCTION_CALL = 'MALFORMED_FUNCTION_CALL'


### PR DESCRIPTION
using the latest version `google-genai==1.39.0`, i'm getting 

```
HTTP Request: POST https://aiplatform.googleapis.com/v1beta1/projects/[project id]/locations/global/publishers/google/models/gemini-2.5-flash-image-preview:generateContent "HTTP/1.1 200 OK"
/usr/local/lib/python3.12/site-packages/google/genai/_common.py:493: UserWarning: IMAGE_PROHIBITED_CONTENT is not a valid FinishReason
  warnings.warn(f"{value} is not a valid {cls.__name__}")
```

This PR adds the value so we can check against it