### PR TITLE
fix(types): restore AudioTranscriptionConfig fields (enable_output, enable_input)

### DIFF
--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -2774,3 +2774,8 @@ def test_user_content_unsupported_type_in_list():
 def test_user_content_unsupported_role():
   with pytest.raises(TypeError):
     types.UserContent(role='model', parts=['hi'])
+
+def test_audio_transcription_config_fields():
+    cfg = types.AudioTranscriptionConfig(enable_output=True, enable_input=False)
+    assert cfg.enable_output is True
+    assert cfg.enable_input is False

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -13932,13 +13932,25 @@ ContextWindowCompressionConfigOrDict = Union[
 class AudioTranscriptionConfig(_common.BaseModel):
   """The audio transcription configuration in Setup."""
 
-  pass
+  enable_output: Optional[bool] = Field(
+      default=True,
+      description="Enable transcription of model's audio output.",
+  )
+
+  enable_input: Optional[bool] = Field(
+      default=True,
+      description="Enable transcription of client audio input.",
+  )
 
 
 class AudioTranscriptionConfigDict(TypedDict, total=False):
   """The audio transcription configuration in Setup."""
 
-  pass
+  enable_output: Optional[bool]
+  """Enable transcription of model's audio output."""
+
+  enable_input: Optional[bool]
+  """Enable transcription of client audio input."""
 
 
 AudioTranscriptionConfigOrDict = Union[


### PR DESCRIPTION
### Context
In v1.15 the `AudioTranscriptionConfig` class was reduced to a placeholder,
which broke Gemini Live transcription (no config fields were passed to API).

### What this PR does
- Restores `enable_output` and `enable_input` fields in `AudioTranscriptionConfig`
  and `AudioTranscriptionConfigDict`.
- Adds a test to verify field behavior.

### Result
Gemini Live sessions can once again request input/output transcriptions,
consistent with v1.14 behavior.

✅ All existing tests pass.
✅ New test confirms config works.