### PR TITLE
Close session after a program termination

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -536,6 +536,9 @@ class AsyncHttpxClient(httpx.AsyncClient):
 
 class BaseApiClient:
   """Client for calling HTTP APIs sending and receiving JSON."""
+  def __del__(self):
+    if self._aiohttp_session:
+      asyncio.run(self._aiohttp_session.close())
 
   def __init__(
       self,


### PR DESCRIPTION
```python
import traceback
import sys
import asyncio
from google.genai._api_client import BaseApiClient
from google.oauth2 import service_account


def _unraisable_hook(unraisable, format_exception=traceback.format_exception):
    tb_lines = format_exception(unraisable.exc_type, unraisable.exc_value, unraisable.exc_traceback)
    tb_str = ''.join(tb_lines)
    print(
        tb_str,
        'Unraisable exception error from %r',
        getattr(unraisable, 'object', None),
        (unraisable.exc_type, unraisable.exc_value, unraisable.exc_traceback),
        f'{unraisable.exc_type.__name__}: {unraisable.exc_value}'
    )


sys.unraisablehook = _unraisable_hook

creds = service_account.Credentials.from_service_account_file('....json', scopes=['https://www.googleapis.com/auth/cloud-platform'])
class Clazz:
    def __init__(self):
        self.gemini = BaseApiClient(
            vertexai=True,
            project='...',
            location='us-west1',
            credentials=creds,
        )
        asyncio.get_event_loop().run_until_complete(self.f())
        raise

    async def f(self):
        self.gemini._aiohttp_session = await self.gemini._get_aiohttp_session()


Clazz()
```

Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x0000022EB0FB8070>

If you don't use context managers __aenter__/__aexit__, you need to close the session explicitly in destuctor.
The eventloop does not exist (asyncio.get_running_loop will not work), so you need to create a new one with asyncio.run.

Alternatively, you can use this hook:
```python
self.gemini = ...
# noinspection PyProtectedMember
def close_gemini():
    if self.gemini._api_client._aiohttp_session:
        asyncio.run(self.gemini._api_client._aiohttp_session.close())

atexit.register(close_gemini)
```