### PR TITLE
fix: export LocalTokenizer in __init__.py

### DIFF
--- a/google/genai/__init__.py
+++ b/google/genai/__init__.py
@@ -18,8 +18,9 @@
 from . import types
 from . import version
 from .client import Client
+from .local_tokenizer import LocalTokenizer
 
 
 __version__ = version.__version__
 
-__all__ = ['Client']
+__all__ = ['Client', 'LocalTokenizer']


### PR DESCRIPTION
- Add LocalTokenizer to imports and __all__ list
- Fixes #1580 where LocalTokenizer was not accessible via genai module
- LocalTokenizer was added in PR #1280 but was missing from exports