### PR TITLE
Fix: `client.file_search_stores.documents.list()` fails to propagate parent parameter

### DIFF
--- a/google/genai/documents.py
+++ b/google/genai/documents.py
@@ -86,6 +86,12 @@ def _ListDocumentsConfig_to_mldev(
         ['_query', 'pageToken'],
         getv(from_object, ['page_token']),
     )
+    
+  if getv(from_object, ['parent']) is not None:
+    setv(
+      parent_object, 
+      ['_url', 'parent'], getv(from_object, ['parent'])
+         )
 
   return to_object
 


### PR DESCRIPTION
Closes #1661

Hi @janasangeetha !

This PR fixes a bug where `client.file_search_stores.documents.list()` was not properly propagating the parent parameter to the underlying API request.

Problem
When users called `documents.list(parent="file_search_stores/{store_id}")`, the parent parameter was being ignored during parameter transformation, causing the API call to fail because it couldn't determine which file search store to query.

Root Cause
The `_ListDocumentsConfig_to_mldev()` function `google\genai\documents.py` in  was not extracting and setting the parent parameter into the request URL.

Solution
Added proper handling of the parent parameter by setting it in the _url section of the request object:

`
if getv(from_object, ['parent']) is not None:
    setv(parent_object, ['_url', 'parent'], getv(from_object, ['parent']))
`