### PR TITLE
fix: Remove __del__ finalizers from async clients to prevent unawaite…

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -514,23 +514,17 @@ class SyncHttpxClient(httpx.Client):
 
 
 class AsyncHttpxClient(httpx.AsyncClient):
-  """Async httpx client."""
+  """Async httpx client.
+
+  Note: This client must be explicitly closed using 'await client.aclose()'
+  to properly release resources. The __del__ finalizer has been removed to
+  prevent creating unawaited asyncio tasks during garbage collection.
+  """
 
   def __init__(self, **kwargs: Any) -> None:
     """Initializes the httpx client."""
     kwargs.setdefault('follow_redirects', True)
     super().__init__(**kwargs)
-
-  def __del__(self) -> None:
-    try:
-      if self.is_closed:
-        return
-    except Exception:
-      pass
-    try:
-      asyncio.get_running_loop().create_task(self.aclose())
-    except Exception:
-      pass
 
 
 class BaseApiClient:

--- a/google/genai/client.py
+++ b/google/genai/client.py
@@ -131,12 +131,6 @@ class AsyncClient:
   ) -> None:
     await self.aclose()
 
-  def __del__(self) -> None:
-    try:
-      asyncio.get_running_loop().create_task(self.aclose())
-    except Exception:
-      pass
-
 
 class DebugConfig(pydantic.BaseModel):
   """Configuration options that change client network behavior when testing."""


### PR DESCRIPTION
## Summary

Removes `__del__` finalizers from `AsyncHttpxClient` and `AsyncClient` to prevent "Task was destroyed but it is pending!" warnings during garbage collection.

## Problem

Fixes #1709
Related: google/adk-python#3550

The `__del__` methods in async clients use `create_task(self.aclose())` without awaiting, creating orphaned tasks that cause asyncio warnings:

```
asyncio - ERROR - Task was destroyed but it is pending!
task: <Task pending coro=<AsyncClient.aclose()>>
```

This occurs because `__del__` is synchronous and cannot properly handle async cleanup.

## Changes

**Modified:**
- `google/genai/_api_client.py` - Remove `AsyncHttpxClient.__del__`
- `google/genai/client.py` - Remove `AsyncClient.__del__`

**Note:** Sync client `__del__` methods unchanged (they use sync `close()`).

## Migration

Async clients now require explicit cleanup:

```python
# Recommended: use context manager
async with genai.Client(...).aio as client:
    response = await client.models.generate_content(...)

# Or: explicit close
client = genai.Client(...).aio
response = await client.models.generate_content(...)
await client.aclose()  # Required
```

## Testing

Ran existing tests:
```
pytest google/genai/tests/client/test_client_initialization.py -v
============================== 70 passed in 2.99s ==============================
```
