### PR TITLE
feat: add optional images dependency group for pillow

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 [project.optional-dependencies]
 aiohttp = ["aiohttp<3.13.3"]
 local-tokenizer = ["sentencepiece>=0.2.0", "protobuf"]
+images = ["pillow>=8.0.0"]
 
 [project.urls]
 Homepage = "https://github.com/googleapis/python-genai"


### PR DESCRIPTION
#1761
Add an images optional dependency group following the existing pattern for aiohttp and local-tokenizer.

```python
[project.optional-dependencies]
aiohttp = ["aiohttp<3.13.3"]
local-tokenizer = ["sentencepiece>=0.2.0", "protobuf"]
images = ["pillow>=8.0.0"]  # Added
```
Users can now install with:

```bash
pip install google-genai[images]
```