### PR TITLE
Type hint on example doesn't seem to work?

### DIFF
--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -5405,10 +5405,10 @@ GenerateContentConfigOrDict = Union[
 ]
 
 
-ContentListUnion = Union[ContentUnion, list[ContentUnion]]
+ContentListUnion = Union[ContentUnion, Sequence[ContentUnion]]
 
 
-ContentListUnionDict = Union[ContentUnionDict, list[ContentUnionDict]]
+ContentListUnionDict = Union[ContentUnionDict, Sequence[ContentUnionDict]]
 
 
 class _GenerateContentParameters(_common.BaseModel):


### PR DESCRIPTION
The type hint for `Content` should be `Sequence`. 

When running the examples from the repo with a prompt and an uploaded image, mypy shows a type hint error.
```
import io
import os
from pathlib import Path

from dotenv import load_dotenv
from google import genai
from google.genai import types
from PIL import Image

load_dotenv()

client = genai.Client(api_key=os.getenv("GEMINI_API_KEY"))
model = "gemini-2.5-flash-image"

output_path = Path("local_dev") / "image.png"
uploaded_file = client.files.upload(file=output_path, config=types.UploadFileConfig(mime_type="image/png"))
print(f"Uploaded file: {uploaded_file.name}")

prompt = "Add people to the scene"
response = client.models.generate_content(model=model, contents=[uploaded_file, prompt])
#                                                               ^^^^^^^^^^^^^^^^^^^^^^^^

Argument "contents" to "generate_content" of "Models" has incompatible type "list[object]"; expected "Content | ContentDict | str | Image | File | FileDict | Part | PartDict | list[str | Image | File | FileDict | Part | PartDict] | list[Content | ContentDict | str | Image | File | FileDict | Part | PartDict | list[str | Image | File | FileDict | Part | PartDict]]"Mypy[arg-type](https://mypy.readthedocs.io/en/latest/_refs.html#code-arg-type)
```

Setting it to slightly more generic `Sequence` solves the problem. 