### PR TITLE
fix: Remove deprecated _UnionGenericAlias to support Python 3.14+

### DIFF
--- a/google/genai/_automatic_function_calling_util.py
+++ b/google/genai/_automatic_function_calling_util.py
@@ -26,9 +26,9 @@ from . import types
 
 
 if sys.version_info >= (3, 10):
-  VersionedUnionType = builtin_types.UnionType
+  VersionedUnionType = (builtin_types.UnionType, type(Union[int, str]))
 else:
-  VersionedUnionType = typing._UnionGenericAlias  # type: ignore[attr-defined]
+  VersionedUnionType = (type(Union[int, str]),)
 
 
 __all__ = [

--- a/google/genai/_transformers.py
+++ b/google/genai/_transformers.py
@@ -42,11 +42,11 @@ from . import types
 logger = logging.getLogger('google_genai._transformers')
 
 if sys.version_info >= (3, 10):
-  VersionedUnionType = builtin_types.UnionType
+  VersionedUnionType = (builtin_types.UnionType, type(Union[int, str]))
   _UNION_TYPES = (typing.Union, builtin_types.UnionType)
   from typing import TypeGuard
 else:
-  VersionedUnionType = typing._UnionGenericAlias  # type: ignore[attr-defined]
+  VersionedUnionType = (type(Union[int, str]),)
   _UNION_TYPES = (typing.Union,)
   from typing_extensions import TypeGuard
 

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -4251,9 +4251,14 @@ else:
 ToolListUnion = list[ToolUnion]
 ToolListUnionDict = list[ToolUnionDict]
 
-SchemaUnion = Union[
-    dict[Any, Any], type, Schema, builtin_types.GenericAlias, VersionedUnionType  # type: ignore[valid-type]
-]
+if sys.version_info >= (3, 10):
+  SchemaUnion = Union[
+      dict[Any, Any], type, Schema, builtin_types.GenericAlias, builtin_types.UnionType, type(Union[int, str])
+  ]
+else:
+  SchemaUnion = Union[
+      dict[Any, Any], type, Schema, builtin_types.GenericAlias, type(Union[int, str])
+  ]
 SchemaUnionDict = Union[SchemaUnion, SchemaDict]
 
 

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -25,7 +25,7 @@ import logging
 import sys
 import types as builtin_types
 import typing
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union, _UnionGenericAlias  # type: ignore
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 import pydantic
 from pydantic import ConfigDict, Field, PrivateAttr, model_validator
 from typing_extensions import Self, TypedDict
@@ -40,11 +40,11 @@ from ._operations_converters import (
 
 if sys.version_info >= (3, 10):
   # Supports both Union[t1, t2] and t1 | t2
-  VersionedUnionType = Union[builtin_types.UnionType, _UnionGenericAlias]
+  VersionedUnionType = (builtin_types.UnionType, type(Union[int, str]))
   _UNION_TYPES = (typing.Union, builtin_types.UnionType)
 else:
   # Supports only Union[t1, t2]
-  VersionedUnionType = _UnionGenericAlias
+  VersionedUnionType = (type(Union[int, str]),)
   _UNION_TYPES = (typing.Union,)
 
 _is_pillow_image_imported = False

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -28,7 +28,7 @@ import typing
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Union
 import pydantic
 from pydantic import ConfigDict, Field, PrivateAttr, model_validator
-from typing_extensions import Self, TypedDict
+from typing_extensions import Self, TypeAlias, TypedDict
 from . import _common
 from ._operations_converters import (
     _GenerateVideosOperation_from_mldev,
@@ -4251,15 +4251,22 @@ else:
 ToolListUnion = list[ToolUnion]
 ToolListUnionDict = list[ToolUnionDict]
 
-if sys.version_info >= (3, 10):
-  SchemaUnion = Union[
+if typing.TYPE_CHECKING:
+  # For type checkers, use the most complete type (Python 3.10+)
+  SchemaUnion: TypeAlias = Union[
       dict[Any, Any], type, Schema, builtin_types.GenericAlias, builtin_types.UnionType, type(Union[int, str])
   ]
 else:
-  SchemaUnion = Union[
-      dict[Any, Any], type, Schema, builtin_types.GenericAlias, type(Union[int, str])
-  ]
-SchemaUnionDict = Union[SchemaUnion, SchemaDict]
+  # At runtime, use version-appropriate types
+  if sys.version_info >= (3, 10):
+    SchemaUnion: TypeAlias = Union[
+        dict[Any, Any], type, Schema, builtin_types.GenericAlias, builtin_types.UnionType, type(Union[int, str])
+    ]
+  else:
+    SchemaUnion: TypeAlias = Union[
+        dict[Any, Any], type, Schema, builtin_types.GenericAlias, type(Union[int, str])
+    ]
+SchemaUnionDict: TypeAlias = Union[SchemaUnion, SchemaDict]
 
 
 class LatLng(_common.BaseModel):


### PR DESCRIPTION
## Summary
Fixes deprecation warnings in Python 3.14 by removing usage of private `typing._UnionGenericAlias` API.

## Changes
- Replaced `_UnionGenericAlias` with tuple-based `isinstance()` checks using `type(Union[int, str])`
- Modified 3 files: `types.py`, `_transformers.py`, `_automatic_function_calling_util.py`
- Maintains compatibility with both `Union[T1, T2]` and `T1 | T2` syntax

## Background
`_UnionGenericAlias` is a private API deprecated in Python 3.14 and scheduled for removal in Python 3.17. The new approach avoids private APIs while maintaining identical functionality for runtime type checking.

## Testing
- Verified the fix resolves deprecation warnings on Python 3.14
- No changes to public API or behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)