### PR TITLE
fix: Set GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES to false for bound tokens

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -538,6 +538,10 @@ class AsyncHttpxClient(httpx.AsyncClient):
 class BaseApiClient:
   """Client for calling HTTP APIs sending and receiving JSON."""
 
+  ## Set GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES to false
+  ## to disable bound token sharing.
+  os.Setenv("GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES", "false")
+
   def __init__(
       self,
       vertexai: Optional[bool] = None,


### PR DESCRIPTION
As a short term fix we are setting GOOGLE_API_PREVENT_AGENT_TOKEN_SHARING_FOR_GCP_SERVICES to false for bound tokens for Agents