### PR TITLE
fix: replace bare except with except Exception in enum __new__

### DIFF
--- a/google/genai/_common.py
+++ b/google/genai/_common.py
@@ -656,7 +656,7 @@ class CaseInSensitiveEnum(str, enum.Enum):
           unknown_enum_val._name_ = str(value)  # pylint: disable=protected-access
           unknown_enum_val._value_ = value  # pylint: disable=protected-access
           return unknown_enum_val
-        except:
+        except Exception:
           return None
 
 


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` in `_common.py`'s enum `__new__` method. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, which should propagate normally.