### PR TITLE
fix: guard against missing _async_httpx_client in aclose()

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -2101,7 +2101,9 @@ class BaseApiClient:
     """Closes the API async client."""
     # Let users close the custom client explicitly by themselves. Otherwise,
     # close the client when the object is garbage collected.
-    if not self._http_options.httpx_async_client:
+    if not self._http_options.httpx_async_client and getattr(
+        self, '_async_httpx_client', None
+    ):
       await self._async_httpx_client.aclose()  # type: ignore[union-attr]
     if self._aiohttp_session and not self._http_options.aiohttp_client:
       await self._aiohttp_session.close()


### PR DESCRIPTION
## Problem

When `BaseApiClient.__init__` raises before `_async_httpx_client` is assigned (e.g. an auth error thrown before any HTTP call is made), `__del__` still schedules `aclose()` as an asyncio task. That task then crashes with:

```
AttributeError: 'BaseApiClient' object has no attribute '_async_httpx_client'
Task exception was never retrieved
future: <Task finished name='Task-...' coro=<BaseApiClient.aclose()> exception=AttributeError(...)>
```

The exception surfaces as an **unhandled asyncio task exception** — swallowed silently in production unless `PYTHONASYNCIODEBUG=1` is set, making it hard to spot.

## Minimal repro (v1.66.0)

```python
import asyncio, os
os.environ.pop("GOOGLE_API_KEY", None)
from google import genai
client = genai.Client(api_key="")
# trigger any async call — the __del__ task fires after GC and crashes
asyncio.run(client.aio.models.generate_content("gemini-2.0-flash", contents="hi"))
```

Traceback:
```
Task exception was never retrieved
future: <Task finished name='Task-18' coro=<BaseApiClient.aclose() done, defined at .../google/genai/_api_client.py:2100> exception=AttributeError("'BaseApiClient' object has no attribute '_async_httpx_client'")>
  File ".../google/genai/_api_client.py", line 2105, in aclose
    await self._async_httpx_client.aclose()
AttributeError: 'BaseApiClient' object has no attribute '_async_httpx_client'
```

## Fix

`close()` already guards the equivalent sync path with `and self._httpx_client`. Apply the same pattern to `aclose()` using `getattr(..., None)` to safely handle the case where `_async_httpx_client` was never set:

```python
# before
if not self._http_options.httpx_async_client:
    await self._async_httpx_client.aclose()

# after
if not self._http_options.httpx_async_client and getattr(self, '_async_httpx_client', None):
    await self._async_httpx_client.aclose()
```

One-line change, no behaviour difference in the normal path.