### PR TITLE
fix(vertex): convert GoogleSearch excludeDomains to camelCase

### DIFF
--- a/README.md
+++ b/README.md
@@ -918,6 +918,10 @@ output might be lower in quality.
 
 #### JSON Schema support
 
+Use `response_json_schema` when you want to pass a standard JSON Schema
+dictionary directly. If you are passing Python types, Pydantic models, or
+other SDK-native schema helpers, use `response_schema` instead.
+
 Schemas can be provided as standard JSON schema.
 
 ```python
@@ -954,7 +958,8 @@ print(response.text)
 
 #### Pydantic Model Schema support
 
-Schemas can be provided as Pydantic Models.
+Schemas can also be provided as Python types or Pydantic models through
+`response_schema`.
 
 ```python
 from pydantic import BaseModel

--- a/google/genai/models.py
+++ b/google/genai/models.py
@@ -2911,6 +2911,33 @@ def _GoogleSearch_to_mldev(
   return to_object
 
 
+def _GoogleSearch_to_vertex(
+    from_object: Union[dict[str, Any], object],
+    parent_object: Optional[dict[str, Any]] = None,
+    root_object: Optional[Union[dict[str, Any], object]] = None,
+) -> dict[str, Any]:
+  to_object: dict[str, Any] = {}
+  if getv(from_object, ['search_types']) is not None:
+    setv(to_object, ['searchTypes'], getv(from_object, ['search_types']))
+
+  if getv(from_object, ['blocking_confidence']) is not None:
+    setv(
+        to_object,
+        ['blockingConfidence'],
+        getv(from_object, ['blocking_confidence']),
+    )
+
+  if getv(from_object, ['exclude_domains']) is not None:
+    setv(to_object, ['excludeDomains'], getv(from_object, ['exclude_domains']))
+
+  if getv(from_object, ['time_range_filter']) is not None:
+    raise ValueError(
+        'time_range_filter parameter is not supported in Vertex AI.'
+    )
+
+  return to_object
+
+
 def _ImageConfig_to_mldev(
     from_object: Union[dict[str, Any], object],
     parent_object: Optional[dict[str, Any]] = None,
@@ -4199,7 +4226,13 @@ def _Tool_to_vertex(
     raise ValueError('file_search parameter is not supported in Vertex AI.')
 
   if getv(from_object, ['google_search']) is not None:
-    setv(to_object, ['googleSearch'], getv(from_object, ['google_search']))
+    setv(
+        to_object,
+        ['googleSearch'],
+        _GoogleSearch_to_vertex(
+            getv(from_object, ['google_search']), to_object, root_object
+        ),
+    )
 
   if getv(from_object, ['google_maps']) is not None:
     setv(to_object, ['googleMaps'], getv(from_object, ['google_maps']))

--- a/google/genai/tests/models/test_generate_content.py
+++ b/google/genai/tests/models/test_generate_content.py
@@ -25,6 +25,7 @@ import logging
 import sys
 from ... import _transformers as t
 from ... import errors
+from ... import models as models_module
 from ... import types
 from .. import pytest_helper
 from enum import Enum
@@ -875,6 +876,22 @@ def test_model_selection_config_pydantic(client):
       ),
   )
   assert response.text
+
+
+def test_vertex_google_search_exclude_domains_is_camel_cased():
+  tool = types.Tool(
+      google_search=types.GoogleSearch(
+          exclude_domains=['amazon.com', 'facebook.com']
+      )
+  )
+
+  request_tool = models_module._Tool_to_vertex(tool)
+
+  assert request_tool == {
+      'googleSearch': {
+          'excludeDomains': ['amazon.com', 'facebook.com'],
+      }
+  }
 
 
 def test_sdk_logger_logs_warnings_once(client, caplog):


### PR DESCRIPTION
## Summary
- restore explicit Vertex conversion for `Tool.google_search`
- camel-case `exclude_domains` to `excludeDomains` in Vertex requests
- add a regression test that checks the serialized Vertex tool payload directly

## Testing
- `python3 -m py_compile google/genai/models.py google/genai/tests/models/test_generate_content.py`
- `python3 -m pytest google/genai/tests/models/test_generate_content.py -k "exclude_domains_is_camel_cased"` *(not run successfully locally: test import fails because `google.auth` is not installed in this environment)*
