### PR TITLE
fix(vertex): append request path for custom base_url

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -1224,11 +1224,14 @@ class BaseApiClient:
             base_url,
             versioned_path,
         )
-    elif(
-        self.custom_base_url
-        and patched_http_options.base_url_resource_scope == ResourceScope.COLLECTION
-    ):
-      url = join_url_path(base_url, path)
+    elif self.custom_base_url:
+      if (
+          patched_http_options.base_url_resource_scope
+          == ResourceScope.COLLECTION
+      ):
+        url = join_url_path(base_url, path)
+      else:
+        url = join_url_path(base_url, versioned_path)
 
     if self.api_key and self.api_key.startswith('auth_tokens/'):
       raise EphemeralTokenAPIKeyError(

--- a/google/genai/tests/client/test_client_requests.py
+++ b/google/genai/tests/client/test_client_requests.py
@@ -214,8 +214,11 @@ def test_build_request_with_custom_base_url_no_env_vars(monkeypatch):
       build_test_client_no_env_vars(monkeypatch).models._api_client
   )
   request = request_client._build_request(
-      'GET',
-      'test/path',
+      'POST',
+      'publishers/google/models/gemini-2.5-flash-image:generateContent',
       {'key': 'value'},
   )
-  assert request.url == 'https://custom-base-url.com'
+  assert request.url == (
+      'https://custom-base-url.com/v1beta1/'
+      'publishers/google/models/gemini-2.5-flash-image:generateContent'
+  )


### PR DESCRIPTION
## Summary
- append the versioned request path when Vertex AI uses a custom \ outside collection-scoped resources
- preserve the existing collection-scoped custom-base-url behavior
- update the request-builder regression test to assert the full Vertex generateContent path

## Testing
- python3 -m py_compile google/genai/_api_client.py google/genai/tests/client/test_client_requests.py
- python3 -m pytest google/genai/tests/client/test_client_requests.py -k custom_base_url_no_env_vars