### PR TITLE
fix(types): support IntEnum in callable tools

### DIFF
--- a/google/genai/_automatic_function_calling_util.py
+++ b/google/genai/_automatic_function_calling_util.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 
+import enum
 import inspect
 import sys
 import types as builtin_types
@@ -152,6 +153,29 @@ def _parse_schema_from_parameter(  # type: ignore[return]
       f' {func_name} is not compatible with the parameter annotation'
       f' {param.annotation}.'
   )
+  if inspect.isclass(param.annotation) and issubclass(param.annotation, enum.Enum):
+    member_values = [member.value for member in param.annotation]
+    if all(isinstance(value, str) for value in member_values):
+      schema.type = _py_builtin_type_to_schema_type[str]
+      schema.enum = member_values
+    elif all(isinstance(value, int) for value in member_values):
+      schema.type = _py_builtin_type_to_schema_type[int]
+      schema.enum = [str(value) for value in member_values]
+    else:
+      raise ValueError(
+          f'Enum type {param.annotation} must have members that are all'
+          ' strings or all integers.'
+      )
+
+    if param.default is not inspect.Parameter.empty:
+      default_value = param.default
+      if isinstance(default_value, param.annotation):
+        default_value = default_value.value
+
+      if default_value not in member_values:
+        raise ValueError(default_value_error_msg)
+      schema.default = default_value
+    return schema
   if _is_builtin_primitive_or_compound(param.annotation):
     if param.default is not inspect.Parameter.empty:
       if not _is_default_value_compatible(param.default, param.annotation):

--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -18,6 +18,7 @@ import copy
 import json
 import sys
 import typing
+from enum import IntEnum
 from typing import Optional, assert_never
 import PIL.Image
 import pydantic
@@ -2540,6 +2541,43 @@ def test_function_with_tuple_contains_unevaluated_items():
 
   assert actual_schema_mldev.parameters_json_schema == expected_parameters_json_schema
   assert actual_schema_vertex.parameters_json_schema == expected_parameters_json_schema
+
+
+def test_function_with_int_enum_parameter():
+
+  class DaysEnum(IntEnum):
+    ONE = 1
+    FIVE = 5
+    TEN = 10
+
+  def func_under_test(days: DaysEnum) -> str:
+    """test IntEnum parameter."""
+    return ''
+
+  expected_schema = types.FunctionDeclaration(
+      name='func_under_test',
+      parameters=types.Schema(
+          type='OBJECT',
+          properties={
+              'days': types.Schema(
+                  type='INTEGER',
+                  enum=['1', '5', '10'],
+              ),
+          },
+          required=['days'],
+      ),
+      description='test IntEnum parameter.',
+  )
+
+  actual_schema_mldev = types.FunctionDeclaration.from_callable(
+      client=mldev_client, callable=func_under_test
+  )
+  actual_schema_vertex = types.FunctionDeclaration.from_callable(
+      client=vertex_client, callable=func_under_test
+  )
+
+  assert actual_schema_mldev == expected_schema
+  assert actual_schema_vertex == expected_schema
 
 
 def test_function_gemini_api(monkeypatch):


### PR DESCRIPTION
## Summary
- handle Enum annotations directly in automatic callable schema parsing instead of falling through the generic Pydantic fallback
- preserve integer-backed enums as INTEGER schemas while serializing enum values in the string form expected by the SDK schema model
- add a FunctionDeclaration.from_callable regression test for IntEnum parameters

## Testing
- python3 -m py_compile google/genai/_automatic_function_calling_util.py google/genai/tests/types/test_types.py
- python3 -m pytest google/genai/tests/types/test_types.py -k int_enum_parameter (fails locally during test startup: ModuleNotFoundError: No module named 'google.auth')