### PR TITLE
feat(caches): support labels in cached content config

### DIFF
--- a/google/genai/caches.py
+++ b/google/genai/caches.py
@@ -197,6 +197,9 @@ def _CreateCachedContentConfig_to_vertex(
   if getv(from_object, ['display_name']) is not None:
     setv(parent_object, ['displayName'], getv(from_object, ['display_name']))
 
+  if getv(from_object, ['labels']) is not None:
+    setv(parent_object, ['labels'], getv(from_object, ['labels']))
+
   if getv(from_object, ['contents']) is not None:
     setv(
         parent_object,

--- a/google/genai/tests/caches/test_cache_labels.py
+++ b/google/genai/tests/caches/test_cache_labels.py
@@ -1,0 +1,43 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from ... import caches
+from ... import types
+
+
+def test_create_cached_content_config_to_vertex_includes_labels():
+  parent_object = {}
+
+  caches._CreateCachedContentConfig_to_vertex(
+      types.CreateCachedContentConfig(
+          display_name='test cache',
+          labels={'team': 'genai', 'use_case': 'billing'},
+      ),
+      parent_object,
+  )
+
+  assert parent_object['labels'] == {
+      'team': 'genai',
+      'use_case': 'billing',
+  }
+
+
+def test_cached_content_accepts_labels():
+  cached_content = types.CachedContent(
+      name='cachedContents/123',
+      labels={'team': 'genai'},
+  )
+
+  assert cached_content.labels == {'team': 'genai'}

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -14333,6 +14333,10 @@ class CreateCachedContentConfig(_common.BaseModel):
       description="""The user-generated meaningful display name of the cached content.
       """,
   )
+  labels: Optional[dict[str, str]] = Field(
+      default=None,
+      description="""User specified labels to track billing usage.""",
+  )
   contents: Optional[ContentListUnion] = Field(
       default=None,
       description="""The content to cache.
@@ -14382,6 +14386,9 @@ class CreateCachedContentConfigDict(TypedDict, total=False):
   display_name: Optional[str]
   """The user-generated meaningful display name of the cached content.
       """
+
+  labels: Optional[dict[str, str]]
+  """User specified labels to track billing usage."""
 
   contents: Optional[ContentListUnionDict]
   """The content to cache.
@@ -14506,6 +14513,10 @@ class CachedContent(_common.BaseModel):
       default=None,
       description="""The user-generated meaningful display name of the cached content.""",
   )
+  labels: Optional[dict[str, str]] = Field(
+      default=None,
+      description="""User specified labels to track billing usage.""",
+  )
   model: Optional[str] = Field(
       default=None,
       description="""The name of the publisher model to use for cached content.""",
@@ -14534,6 +14545,9 @@ class CachedContentDict(TypedDict, total=False):
 
   display_name: Optional[str]
   """The user-generated meaningful display name of the cached content."""
+
+  labels: Optional[dict[str, str]]
+  """User specified labels to track billing usage."""
 
   model: Optional[str]
   """The name of the publisher model to use for cached content."""


### PR DESCRIPTION
## Summary
- add labels to CreateCachedContentConfig and CachedContent
- serialize cache labels on the Vertex cached-content create path
- add focused tests for Vertex serialization and cached-content parsing

## Testing
- python3 -m py_compile google/genai/caches.py google/genai/types.py google/genai/tests/caches/test_cache_labels.py
- python3 -m pytest google/genai/tests/caches/test_cache_labels.py