### PR TITLE
fix(models): serialize multimodal function response display names

### DIFF
--- a/google/genai/models.py
+++ b/google/genai/models.py
@@ -3429,10 +3429,15 @@ def _Part_to_mldev(
     )
 
   if getv(from_object, ['function_response']) is not None:
+    function_response = getv(from_object, ['function_response'])
+    if isinstance(function_response, dict):
+      function_response = types.FunctionResponse.model_validate(
+          function_response
+      )
     setv(
         to_object,
         ['functionResponse'],
-        getv(from_object, ['function_response']),
+        function_response.model_dump(by_alias=True, exclude_none=True, mode='json'),
     )
 
   if getv(from_object, ['inline_data']) is not None:
@@ -3500,10 +3505,15 @@ def _Part_to_vertex(
     setv(to_object, ['functionCall'], getv(from_object, ['function_call']))
 
   if getv(from_object, ['function_response']) is not None:
+    function_response = getv(from_object, ['function_response'])
+    if isinstance(function_response, dict):
+      function_response = types.FunctionResponse.model_validate(
+          function_response
+      )
     setv(
         to_object,
         ['functionResponse'],
-        getv(from_object, ['function_response']),
+        function_response.model_dump(by_alias=True, exclude_none=True, mode='json'),
     )
 
   if getv(from_object, ['inline_data']) is not None:

--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -22,6 +22,7 @@ from typing import Optional, assert_never
 import PIL.Image
 import pydantic
 import pytest
+from ... import models
 from ... import types
 
 _is_mcp_imported = False
@@ -113,6 +114,28 @@ def test_factory_method_part_from_function_response_with_multi_modal_parts():
   assert my_part.function_response.parts[0].inline_data.data == b'123'
   assert my_part.function_response.parts[0].inline_data.mime_type == 'image/png'
   assert isinstance(my_part, SubPart)
+
+
+def test_part_to_mldev_serializes_function_response_display_name():
+  my_part = SubPart.from_function_response(
+      name='get_image',
+      response={'image_ref': {'$ref': 'instrument.jpg'}},
+      parts=[
+          {
+              'inline_data': {
+                  'data': b'123',
+                  'mime_type': 'image/jpeg',
+                  'display_name': 'instrument.jpg',
+              }
+          }
+      ],
+  )
+
+  serialized = models._Part_to_mldev(my_part)
+
+  assert serialized['functionResponse']['parts'][0]['inlineData'][
+      'displayName'
+  ] == 'instrument.jpg'
 
 
 def test_factory_method_function_response_part_from_bytes():


### PR DESCRIPTION
## Summary
- serialize nested function_response payloads with alias-aware camelCase keys
- preserve displayName inside multimodal function-response parts so $ref names can match the uploaded media part
- add a focused regression test for the generated wire shape

## Testing
- python3 -m py_compile google/genai/models.py google/genai/tests/types/test_types.py
- python3 -m pytest google/genai/tests/types/test_types.py -k function_response_display_name