### PR TITLE
feat(models): allow labels in Gemini API generate_content

### DIFF
--- a/google/genai/models.py
+++ b/google/genai/models.py
@@ -1296,7 +1296,7 @@ def _GenerateContentConfig_to_mldev(
     )
 
   if getv(from_object, ['labels']) is not None:
-    raise ValueError('labels parameter is not supported in Gemini API.')
+    setv(parent_object, ['labels'], getv(from_object, ['labels']))
 
   if getv(from_object, ['cached_content']) is not None:
     setv(

--- a/google/genai/tests/models/test_generate_content.py
+++ b/google/genai/tests/models/test_generate_content.py
@@ -29,6 +29,8 @@ from ... import types
 from .. import pytest_helper
 from enum import Enum
 
+from ... import models as models_module
+
 GEMINI_FLASH_LATEST = 'gemini-2.5-flash'
 GEMINI_FLASH_2_0 = 'gemini-2.0-flash-001'
 GEMINI_FLASH_IMAGE_LATEST = 'gemini-2.5-flash-image'
@@ -62,6 +64,19 @@ class InstrumentEnum(Enum):
   WOODWIND = 'Woodwind'
   BRASS = 'Brass'
   KEYBOARD = 'Keyboard'
+
+
+def test_generate_content_labels_are_serialized_for_mldev():
+  request = models_module._GenerateContentConfig_to_mldev(
+      {
+          'labels': {'purpose': 'exploration', 'environment': 'development'},
+      }
+  )
+
+  assert request['labels'] == {
+      'purpose': 'exploration',
+      'environment': 'development',
+  }
 
 
 test_table: list[pytest_helper.TestTableItem] = [


### PR DESCRIPTION
Summary
- allow GenerateContentConfig.labels to flow through the Gemini Developer API request mapper instead of raising a hardcoded error
- add a focused regression test for _GenerateContentConfig_to_mldev() label serialization

Testing
- python3 -m py_compile google/genai/models.py google/genai/tests/models/test_generate_content.py
- tried GOOGLE_GENAI_REPLAYS_DIRECTORY=/tmp/python-genai-replays python3 -m pytest google/genai/tests/models/test_generate_content.py -k generate_content_labels_are_serialized_for_mldev
- local pytest import was blocked because this environment is missing google-auth (ModuleNotFoundError: No module named 'google')