### PR TITLE
fix(retry): retry on httpx.TimeoutException with HttpRetryOptions

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -507,7 +507,8 @@ def retry_args(options: Optional[HttpRetryOptions]) -> _common.StringDict:
   stop = tenacity.stop_after_attempt(options.attempts or _RETRY_ATTEMPTS)
   retriable_codes = options.http_status_codes or _RETRY_HTTP_STATUS_CODES
   retry = tenacity.retry_if_exception(
-      lambda e: isinstance(e, errors.APIError) and e.code in retriable_codes,
+      lambda e: (isinstance(e, errors.APIError) and e.code in retriable_codes)
+      or isinstance(e, (httpx.TimeoutException, httpx.ConnectError)),
   )
   wait = tenacity.wait_exponential_jitter(
       initial=options.initial_delay or _RETRY_INITIAL_DELAY,

--- a/google/genai/tests/client/test_retries.py
+++ b/google/genai/tests/client/test_retries.py
@@ -187,6 +187,23 @@ def test_retry_args_enabled_with_custom_values_are_not_overridden():
       assert not retry.predicate(e)
 
 
+def test_retry_args_retries_httpx_transport_errors():
+  # httpx transport errors (timeouts, connect errors) bypass APIError but are
+  # transient infrastructure failures, so the predicate must still retry them
+  # when HttpRetryOptions is configured. See issue #2337.
+  args = api_client.retry_args(types.HttpRetryOptions())
+  retry = args['retry']
+
+  assert retry.predicate(httpx.TimeoutException('stalled'))
+  assert retry.predicate(httpx.ReadTimeout('read stalled'))
+  assert retry.predicate(httpx.ConnectTimeout('connect stalled'))
+  assert retry.predicate(httpx.ConnectError('connect refused'))
+
+  # Unrelated transport errors are not retried.
+  assert not retry.predicate(httpx.InvalidURL('bad url'))
+  assert not retry.predicate(ValueError('not a transport error'))
+
+
 def _patch_auth_default():
   return mock.patch(
       'google.auth.default',


### PR DESCRIPTION
Closes #2337.

`httpx.TimeoutException` was not in the retryable-exception tuple, so requests timed out and surfaced the error even when `HttpRetryOptions` was configured. Added the exception (along with `httpx.ConnectError`) so transient transport failures retry like other recoverable errors.

Test added in `google/genai/tests/client/test_retries.py::test_retry_args_retries_httpx_transport_errors`.
