### PR TITLE
docs: add note about maximum images limit and asyncio workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -1175,8 +1175,10 @@ print(response)
 ### Imagen
 
 #### Generate Images
+> **Note:** Maximum images per request is 4. For more than 4 images, send multiple parallel requests using `asyncio`. See the asyncio example below.
 
 ```python
+
 from google.genai import types
 
 response1 = client.models.generate_images(


### PR DESCRIPTION
Added a note clarifying that the maximum number of images  per request is 4. Suggested asyncio as workaround for  generating more than 4 images.