### PR TITLE
fix: send `embedding_model` as query parameter in `fileSearchStores.create`

### DIFF
--- a/google/genai/file_search_stores.py
+++ b/google/genai/file_search_stores.py
@@ -51,7 +51,7 @@ def _CreateFileSearchStoreConfig_to_mldev(
   if getv(from_object, ['embedding_model']) is not None:
     setv(
         parent_object,
-        ['embeddingModel'],
+        ['_query', 'embedding_model'],
         t.t_model(api_client, getv(from_object, ['embedding_model'])),
     )
 


### PR DESCRIPTION
## PR Description

### What the EAP docs say should work:

```python
store = client.file_search_stores.create(
    config={
        "display_name": "Multimodal Catalog",
        "embedding_model": "models/gemini-embedding-2"
    }
)
```
### What the SDK does in `v1.75.0` (broken):

The serializer `_CreateFileSearchStoreConfig_to_mldev` places `embeddingModel` in the request body: `setv(parent_object, ['embeddingModel'], ...)`

```
This sends:

POST /v1beta/fileSearchStores
Body: {"displayName": "...", "embeddingModel": "models/gemini-embedding-2"}
```

The API rejects it:

<img width="1427" height="291" alt="image" src="https://github.com/user-attachments/assets/17434adf-ed98-416f-ad2d-a956e9d17d5a" />

```
400 INVALID_ARGUMENT. Invalid JSON payload received.
Unknown name "embeddingModel" at 'file_search_store': Cannot find field.
```

Seems like a regression from- https://github.com/kausmeows/python-genai/commit/dd11222b9eb42e60f81a8a8e268d770925d625bb ?

Because as per EAP the API still accepts it as query. With this fix the integration is working in Agno. Had to monkey patch here rn- https://github.com/agno-agi/agno/pull/7788