### PR TITLE
fix: allow disabling response schema propertyOrdering

### DIFF
--- a/google/genai/_transformers.py
+++ b/google/genai/_transformers.py
@@ -834,7 +834,10 @@ def process_schema(
   visited_dicts_path.remove(id(schema))
 
 def _process_enum(
-    enum: EnumMeta, client: Optional[_api_client.BaseApiClient]
+    enum: EnumMeta,
+    client: Optional[_api_client.BaseApiClient],
+    *,
+    order_properties: bool = True,
 ) -> types.Schema:
   is_integer_enum = False
 
@@ -857,7 +860,7 @@ def _process_enum(
     placeholder: enum_to_process  # type: ignore[valid-type]
 
   enum_schema = Placeholder.model_json_schema()
-  process_schema(enum_schema, client)
+  process_schema(enum_schema, client, order_properties=order_properties)
   enum_schema = enum_schema['properties']['placeholder']
   return types.Schema.model_validate(enum_schema)
 
@@ -874,21 +877,23 @@ def _is_type_dict_str_any(
 def t_schema(
     client: Optional[_api_client.BaseApiClient],
     origin: Union[types.SchemaUnionDict, Any],
+    *,
+    order_properties: bool = True,
 ) -> Optional[types.Schema]:
   if not origin:
     return None
   if isinstance(origin, dict) and _is_type_dict_str_any(origin):
-    process_schema(origin, client)
+    process_schema(origin, client, order_properties=order_properties)
     return types.Schema.model_validate(origin)
   if isinstance(origin, EnumMeta):
-    return _process_enum(origin, client)
+    return _process_enum(origin, client, order_properties=order_properties)
   if is_duck_type_of(origin, types.Schema):
     if dict(origin) == dict(types.Schema()):  # type: ignore [arg-type]
       # response_schema value was coerced to an empty Schema instance because
       # it did not adhere to the Schema field annotation
       _raise_for_unsupported_schema_type(origin)
     schema = origin.model_dump(exclude_unset=True)  # type: ignore[union-attr]
-    process_schema(schema, client)
+    process_schema(schema, client, order_properties=order_properties)
     return types.Schema.model_validate(schema)
 
   if (
@@ -899,7 +904,7 @@ def t_schema(
       and issubclass(origin, pydantic.BaseModel)
   ):
     schema = origin.model_json_schema()
-    process_schema(schema, client)
+    process_schema(schema, client, order_properties=order_properties)
     return types.Schema.model_validate(schema)
   elif (
       isinstance(origin, GenericAlias)
@@ -912,7 +917,7 @@ def t_schema(
       placeholder: origin  # type: ignore[valid-type]
 
     schema = Placeholder.model_json_schema()
-    process_schema(schema, client)
+    process_schema(schema, client, order_properties=order_properties)
     schema = schema['properties']['placeholder']
     return types.Schema.model_validate(schema)
 

--- a/google/genai/batches.py
+++ b/google/genai/batches.py
@@ -1068,7 +1068,14 @@ def _GenerateContentConfig_to_mldev(
     setv(
         to_object,
         ['responseSchema'],
-        t.t_schema(api_client, getv(from_object, ['response_schema'])),
+        t.t_schema(
+            api_client,
+            getv(from_object, ['response_schema']),
+            order_properties=getv(
+                from_object, ['response_schema_property_ordering']
+            )
+            is not False,
+        ),
     )
 
   if getv(from_object, ['response_json_schema']) is not None:

--- a/google/genai/models.py
+++ b/google/genai/models.py
@@ -1259,7 +1259,14 @@ def _GenerateContentConfig_to_mldev(
     setv(
         to_object,
         ['responseSchema'],
-        t.t_schema(api_client, getv(from_object, ['response_schema'])),
+        t.t_schema(
+            api_client,
+            getv(from_object, ['response_schema']),
+            order_properties=getv(
+                from_object, ['response_schema_property_ordering']
+            )
+            is not False,
+        ),
     )
 
   if getv(from_object, ['response_json_schema']) is not None:
@@ -1456,7 +1463,14 @@ def _GenerateContentConfig_to_vertex(
     setv(
         to_object,
         ['responseSchema'],
-        t.t_schema(api_client, getv(from_object, ['response_schema'])),
+        t.t_schema(
+            api_client,
+            getv(from_object, ['response_schema']),
+            order_properties=getv(
+                from_object, ['response_schema_property_ordering']
+            )
+            is not False,
+        ),
     )
 
   if getv(from_object, ['response_json_schema']) is not None:

--- a/google/genai/tests/transformers/test_schema.py
+++ b/google/genai/tests/transformers/test_schema.py
@@ -24,6 +24,7 @@ import pytest
 
 from ... import _transformers
 from ... import client as google_genai_client_module
+from ... import models as models_module
 from ... import types
 
 
@@ -88,6 +89,39 @@ def client(use_vertex):
     yield google_genai_client_module.Client(
         vertexai=use_vertex, api_key='test-api-key'
     )
+
+
+def _get_response_schema_from_generate_content_config(
+    client, config: types.GenerateContentConfig
+) -> types.Schema:
+  if client.vertexai:
+    request = models_module._GenerateContentConfig_to_vertex(
+        client._api_client, config, {}
+    )
+  else:
+    request = models_module._GenerateContentConfig_to_mldev(
+        client._api_client, config, {}
+    )
+  return request['responseSchema']
+
+
+def _assert_no_property_ordering(schema: types.Schema) -> None:
+  assert schema.property_ordering is None
+
+  for sub_schema in (getattr(schema, 'properties', None) or {}).values():
+    _assert_no_property_ordering(sub_schema)
+
+  if getattr(schema, 'items', None) is not None:
+    _assert_no_property_ordering(schema.items)
+
+  for sub_schema in getattr(schema, 'prefix_items', None) or []:
+    _assert_no_property_ordering(sub_schema)
+
+  for sub_schema in getattr(schema, 'any_of', None) or []:
+    _assert_no_property_ordering(sub_schema)
+
+  if isinstance(getattr(schema, 'additional_properties', None), types.Schema):
+    _assert_no_property_ordering(schema.additional_properties)
 
 
 @pytest.mark.parametrize('use_vertex', [True, False])
@@ -693,3 +727,48 @@ def test_t_schema_sets_property_ordering_for_schema_type(client):
 
   transformed_schema = _transformers.t_schema(client, schema)
   assert transformed_schema.property_ordering == ['name', 'population']
+
+
+@pytest.mark.parametrize('use_vertex', [True, False])
+@pytest.mark.parametrize('response_schema_property_ordering', [None, True])
+def test_generate_content_config_defaults_to_property_ordering(
+    client, response_schema_property_ordering
+):
+  config_args = {'response_schema': CountryInfo}
+  if response_schema_property_ordering is not None:
+    config_args['response_schema_property_ordering'] = (
+        response_schema_property_ordering
+    )
+
+  schema = _get_response_schema_from_generate_content_config(
+      client,
+      types.GenerateContentConfig(**config_args),
+  )
+
+  assert schema.property_ordering == list(country_info_fields.keys())
+
+
+@pytest.mark.parametrize('use_vertex', [True, False])
+def test_generate_content_config_can_disable_property_ordering(client):
+  schema = _get_response_schema_from_generate_content_config(
+      client,
+      types.GenerateContentConfig(
+          response_schema=CountryInfo,
+          response_schema_property_ordering=False,
+      ),
+  )
+
+  assert schema.property_ordering is None
+
+
+@pytest.mark.parametrize('use_vertex', [True, False])
+def test_generate_content_config_disables_nested_property_ordering(client):
+  schema = _get_response_schema_from_generate_content_config(
+      client,
+      types.GenerateContentConfig(
+          response_schema=CountryInfoWithCurrency,
+          response_schema_property_ordering=False,
+      ),
+  )
+
+  _assert_no_property_ordering(schema)

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -5932,6 +5932,10 @@ class GenerateContentConfig(_common.BaseModel):
       `response_json_schema` instead.
       """,
   )
+  response_schema_property_ordering: Optional[bool] = Field(
+      default=None,
+      description="""Optional. Controls whether the SDK automatically adds `propertyOrdering` to response schemas derived from `response_schema`. If unset or true, the SDK preserves the default behavior. If false, the SDK does not add `propertyOrdering` unless it is already present in the schema.""",
+  )
   response_json_schema: Optional[Any] = Field(
       default=None,
       description="""Optional. Output schema of the generated response.
@@ -6166,6 +6170,9 @@ class GenerateContentConfigDict(TypedDict, total=False):
       If `response_schema` doesn't process your schema correctly, try using
       `response_json_schema` instead.
       """
+
+  response_schema_property_ordering: Optional[bool]
+  """Optional. Controls whether the SDK automatically adds `propertyOrdering` to response schemas derived from `response_schema`. If unset or true, the SDK preserves the default behavior. If false, the SDK does not add `propertyOrdering` unless it is already present in the schema."""
 
   response_json_schema: Optional[Any]
   """Optional. Output schema of the generated response.


### PR DESCRIPTION
## Summary

Addresses #2418.

Adds a conservative opt-out for SDK-added `propertyOrdering` during response schema processing.

Issue #2418 reports that automatically injected `propertyOrdering` can negatively affect structured output reliability for some long-form extraction workloads. This PR does not change the default behavior globally. Instead, it adds an explicit escape hatch so affected users can disable SDK-added `propertyOrdering` when needed.

By default, behavior is unchanged: schemas generated from `response_schema` continue to include SDK-added `propertyOrdering`.

Users can now explicitly disable that behavior with:

```python
types.GenerateContentConfig(
    response_schema=MyModel,
    response_schema_property_ordering=False,
)

When disabled, the opt-out is threaded through schema transformation recursively, so nested generated schemas also avoid SDK-added propertyOrdering.

Note: types.py, models.py, and batches.py appear to be generated outputs in this public repo. I kept those edits minimal and only changed the public config field and request conversion call sites needed for this option.

Validation

Ran locally on Windows:

python -m pytest google/genai/tests/transformers/test_schema.py -q
python -m pytest google/genai/tests/transformers/test_t_content.py -q
git diff --check

