### PR TITLE
fix: parse service tier in usage metadata

### DIFF
--- a/google/genai/tests/common/test_common.py
+++ b/google/genai/tests/common/test_common.py
@@ -677,6 +677,18 @@ However, we can talk about the **leading contenders** and what they are generall
   assert repr(obj) == expected
 
 
+def test_generate_content_usage_metadata_service_tier():
+  response = types.GenerateContentResponse.model_validate({
+      'usageMetadata': {
+          'promptTokenCount': 1,
+          'totalTokenCount': 1,
+          'serviceTier': 'priority',
+      }
+  })
+
+  assert response.usage_metadata.service_tier == types.ServiceTier.PRIORITY
+
+
 def test_move_value_by_path():
   """Test move_value_by_path function with array wildcard notation."""
   data = {

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -7809,6 +7809,10 @@ class GenerateContentResponseUsageMetadata(_common.BaseModel):
       default=None,
       description="""Output only. A detailed breakdown of the token count for each modality in the prompt.""",
   )
+  service_tier: Optional[ServiceTier] = Field(
+      default=None,
+      description="""Output only. The service tier used for this request.""",
+  )
   thoughts_token_count: Optional[int] = Field(
       default=None,
       description="""Output only. The number of tokens that were part of the model's generated "thoughts" output, if applicable.""",
@@ -7855,6 +7859,9 @@ class GenerateContentResponseUsageMetadataDict(TypedDict, total=False):
 
   prompt_tokens_details: Optional[list[ModalityTokenCountDict]]
   """Output only. A detailed breakdown of the token count for each modality in the prompt."""
+
+  service_tier: Optional[ServiceTier]
+  """Output only. The service tier used for this request."""
 
   thoughts_token_count: Optional[int]
   """Output only. The number of tokens that were part of the model's generated "thoughts" output, if applicable."""


### PR DESCRIPTION
Fixes #2435.\n\nAdds service_tier to GenerateContentResponseUsageMetadata so responses containing usageMetadata.serviceTier validate instead of failing on an extra field, and covers the camelCase response payload with a focused unit test.\n\nValidation:\n- uv run --with pytest pytest google/genai/tests/common/test_common.py -q -k usage_metadata_service_tier\n- python3 -m compileall -q google/genai/types.py google/genai/tests/common/test_common.py\n- git diff --check