### PR TITLE
fix: send Vertex service tier as headers

### DIFF
--- a/google/genai/models.py
+++ b/google/genai/models.py
@@ -35,6 +35,44 @@ from .pagers import AsyncPager, Pager
 
 logger = logging.getLogger('google_genai.models')
 
+_VERTEX_REQUEST_TYPE_HEADER = 'X-Vertex-AI-LLM-Request-Type'
+_VERTEX_SHARED_REQUEST_TYPE_HEADER = 'X-Vertex-AI-LLM-Shared-Request-Type'
+
+
+def _apply_vertex_service_tier_headers(
+    service_tier: Any,
+    request_dict: dict[str, Any],
+    http_options: Optional[types.HttpOptions],
+) -> Optional[types.HttpOptions]:
+  if service_tier is None:
+    return http_options
+
+  request_dict.pop('serviceTier', None)
+  service_tier_value = getattr(service_tier, 'value', service_tier)
+  service_tier_value = str(service_tier_value).lower()
+  if service_tier_value in ('', 'unspecified'):
+    return http_options
+
+  if isinstance(http_options, types.HttpOptions):
+    patched_http_options = http_options.model_copy(deep=True)
+  elif http_options is not None:
+    patched_http_options = types.HttpOptions.model_validate(http_options)
+  else:
+    patched_http_options = types.HttpOptions()
+
+  headers = dict(patched_http_options.headers or {})
+  if service_tier_value == 'standard':
+    headers[_VERTEX_REQUEST_TYPE_HEADER] = 'shared'
+    headers.pop(_VERTEX_SHARED_REQUEST_TYPE_HEADER, None)
+  elif service_tier_value in ('flex', 'priority'):
+    headers[_VERTEX_REQUEST_TYPE_HEADER] = 'shared'
+    headers[_VERTEX_SHARED_REQUEST_TYPE_HEADER] = service_tier_value
+  else:
+    return http_options
+
+  patched_http_options.headers = headers
+  return patched_http_options
+
 
 def _PersonGeneration_to_mldev_enum_validate(enum_value: Any) -> None:
   if enum_value in set(['ALLOW_ALL']):
@@ -4834,6 +4872,10 @@ class Models(_api_module.BaseModule):
         and parameter_model.config.http_options is not None
     ):
       http_options = parameter_model.config.http_options
+    if self._api_client.vertexai and parameter_model.config is not None:
+      http_options = _apply_vertex_service_tier_headers(
+          parameter_model.config.service_tier, request_dict, http_options
+      )
 
     request_dict = _common.convert_to_dict(request_dict)
     request_dict = _common.encode_unserializable_types(request_dict)
@@ -4934,6 +4976,10 @@ class Models(_api_module.BaseModule):
         and parameter_model.config.http_options is not None
     ):
       http_options = parameter_model.config.http_options
+    if self._api_client.vertexai and parameter_model.config is not None:
+      http_options = _apply_vertex_service_tier_headers(
+          parameter_model.config.service_tier, request_dict, http_options
+      )
 
     request_dict = _common.convert_to_dict(request_dict)
     request_dict = _common.encode_unserializable_types(request_dict)
@@ -7020,6 +7066,10 @@ class AsyncModels(_api_module.BaseModule):
         and parameter_model.config.http_options is not None
     ):
       http_options = parameter_model.config.http_options
+    if self._api_client.vertexai and parameter_model.config is not None:
+      http_options = _apply_vertex_service_tier_headers(
+          parameter_model.config.service_tier, request_dict, http_options
+      )
 
     request_dict = _common.convert_to_dict(request_dict)
     request_dict = _common.encode_unserializable_types(request_dict)
@@ -7120,6 +7170,10 @@ class AsyncModels(_api_module.BaseModule):
         and parameter_model.config.http_options is not None
     ):
       http_options = parameter_model.config.http_options
+    if self._api_client.vertexai and parameter_model.config is not None:
+      http_options = _apply_vertex_service_tier_headers(
+          parameter_model.config.service_tier, request_dict, http_options
+      )
 
     request_dict = _common.convert_to_dict(request_dict)
     request_dict = _common.encode_unserializable_types(request_dict)

--- a/google/genai/tests/models/test_generate_content.py
+++ b/google/genai/tests/models/test_generate_content.py
@@ -23,8 +23,10 @@ import pytest
 import json
 import logging
 import sys
+from ... import _api_client
 from ... import _transformers as t
 from ... import errors
+from ... import models as models_module
 from ... import types
 from .. import pytest_helper
 from enum import Enum
@@ -567,7 +569,6 @@ test_table: list[pytest_helper.TestTableItem] = [
                 'service_tier': 'FLEX',
             },
         ),
-        exception_if_vertex='400',
     ),
     pytest_helper.TestTableItem(
         name='test_service_tier_lower',
@@ -578,7 +579,6 @@ test_table: list[pytest_helper.TestTableItem] = [
                 'service_tier': 'flex',
             },
         ),
-        exception_if_vertex='400',
     ),
 ]
 
@@ -2579,3 +2579,40 @@ def test_response_json_schema_with_one_of(client):
   assert resource_config['size'] == 10
   assert 'tier' not in resource_config
   assert set(resource_config.keys()) == {'size'}
+
+
+def test_vertex_service_tier_uses_headers_not_body(
+    use_vertex, replays_prefix, http_options
+):
+  api_client = _api_client.BaseApiClient(
+      vertexai=True, project='test-project', location='global'
+  )
+  models = models_module.Models(api_client)
+  captured_request = {}
+
+  def fake_request(method, path, request_dict, http_options):
+    captured_request['method'] = method
+    captured_request['path'] = path
+    captured_request['request_dict'] = request_dict
+    captured_request['http_options'] = http_options
+    response = _api_client.HttpResponse(headers={})
+    response.body = '{}'
+    return response
+
+  api_client.request = fake_request
+
+  models.generate_content(
+      model='gemini-3-flash-preview',
+      contents='hello',
+      config=types.GenerateContentConfig(
+          service_tier=types.ServiceTier.PRIORITY,
+          http_options=types.HttpOptions(headers={'X-Custom-Header': 'yes'}),
+      ),
+  )
+
+  assert 'serviceTier' not in captured_request['request_dict']
+  assert captured_request['http_options'].headers == {
+      'X-Custom-Header': 'yes',
+      'X-Vertex-AI-LLM-Request-Type': 'shared',
+      'X-Vertex-AI-LLM-Shared-Request-Type': 'priority',
+  }


### PR DESCRIPTION
## Summary
- map Vertex service_tier config to the Vertex service-tier HTTP headers
- remove serviceTier from the Vertex generateContent request body once converted
- preserve existing custom http_options headers when applying the service-tier headers

Fixes #2433

## Testing
- GOOGLE_GENAI_REPLAYS_DIRECTORY=/tmp/python-genai-replays uv run --with pytest --with pytest-asyncio pytest google/genai/tests/models/test_generate_content.py -q -k vertex_service_tier_uses_headers_not_body
- python3 -m compileall -q google/genai/models.py google/genai/tests/models/test_generate_content.py
- git diff --check