### PR TITLE
fix: parse mldev batch input config source

### DIFF
--- a/google/genai/batches.py
+++ b/google/genai/batches.py
@@ -246,16 +246,6 @@ def _BatchJobSource_from_mldev(
   if getv(from_object, ['fileName']) is not None:
     setv(to_object, ['file_name'], getv(from_object, ['fileName']))
 
-  if getv(from_object, ['requests', 'requests']) is not None:
-    setv(
-        to_object,
-        ['inlined_requests'],
-        [
-            _InlinedRequest_from_mldev(item, to_object)
-            for item in getv(from_object, ['requests', 'requests'])
-        ],
-    )
-
   return to_object
 
 

--- a/google/genai/batches.py
+++ b/google/genai/batches.py
@@ -238,6 +238,27 @@ def _BatchJobSource_from_vertex(
   return to_object
 
 
+def _BatchJobSource_from_mldev(
+    from_object: Union[dict[str, Any], object],
+    parent_object: Optional[dict[str, Any]] = None,
+) -> dict[str, Any]:
+  to_object: dict[str, Any] = {}
+  if getv(from_object, ['fileName']) is not None:
+    setv(to_object, ['file_name'], getv(from_object, ['fileName']))
+
+  if getv(from_object, ['requests', 'requests']) is not None:
+    setv(
+        to_object,
+        ['inlined_requests'],
+        [
+            _InlinedRequest_from_mldev(item, to_object)
+            for item in getv(from_object, ['requests', 'requests'])
+        ],
+    )
+
+  return to_object
+
+
 def _BatchJobSource_to_mldev(
     api_client: BaseApiClient,
     from_object: Union[dict[str, Any], object],
@@ -365,6 +386,15 @@ def _BatchJob_from_mldev(
 
   if getv(from_object, ['metadata', 'model']) is not None:
     setv(to_object, ['model'], getv(from_object, ['metadata', 'model']))
+
+  if getv(from_object, ['metadata', 'inputConfig']) is not None:
+    setv(
+        to_object,
+        ['src'],
+        _BatchJobSource_from_mldev(
+            getv(from_object, ['metadata', 'inputConfig']), to_object
+        ),
+    )
 
   if getv(from_object, ['metadata', 'output']) is not None:
     setv(

--- a/google/genai/tests/batches/test_batch_converters.py
+++ b/google/genai/tests/batches/test_batch_converters.py
@@ -1,0 +1,43 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for batch response converters."""
+
+from ... import batches
+from ... import types
+
+
+def test_mldev_batch_job_parses_input_config_src():
+  response = {
+      'name': 'batches/test-batch',
+      'metadata': {
+          'inputConfig': {
+              'fileName': 'files/input-file',
+          },
+          'output': {
+              'responsesFile': 'files/output-file',
+          },
+      },
+  }
+
+  parsed = types.BatchJob._from_response(
+      response=batches._BatchJob_from_mldev(response),
+      kwargs={},
+  )
+
+  assert parsed.src is not None
+  assert parsed.src.file_name == 'files/input-file'
+  assert parsed.dest is not None
+  assert parsed.dest.file_name == 'files/output-file'


### PR DESCRIPTION
Fixes #2367.

## Summary
- parse metadata.inputConfig into BatchJob.src for Gemini Developer API batch responses
- add a converter regression test for MLDev batch input and output file fields

## Tests
- uv run --with pytest pytest google/genai/tests/batches/test_batch_converters.py -q
- git diff --check