### PR TITLE
fix: handle boolean mcp schema values

### DIFF
--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -124,9 +124,12 @@ def set_mcp_usage_header(headers: dict[str, str]) -> None:
 
 
 def _filter_to_supported_schema(
-    schema: _common.StringDict,
-) -> _common.StringDict:
+    schema: Any,
+) -> Any:
   """Filters the schema to only include fields that are supported by JSONSchema."""
+  if not isinstance(schema, dict):
+    return schema
+
   supported_fields: set[str] = set(types.JSONSchema.model_fields.keys())
 
   supported_fields.update([

--- a/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
+++ b/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
@@ -198,6 +198,35 @@ def test_properties_conversion():
   ]
 
 
+def test_bool_additional_properties_conversion():
+  """Test conversion of MCP tools with boolean additionalProperties."""
+  mcp_tools = [
+      mcp_types.Tool(
+          name='tool',
+          description='tool-description',
+          inputSchema={
+              'type': 'object',
+              'properties': {
+                  'payload': {
+                      'type': 'object',
+                      'additionalProperties': False,
+                  },
+              },
+          },
+      ),
+  ]
+
+  result = _mcp_utils.mcp_to_gemini_tools(mcp_tools)
+
+  payload_schema = (
+      result[0]
+      .function_declarations[0]
+      .parameters
+      .properties['payload']
+  )
+  assert payload_schema.type == 'OBJECT'
+
+
 def test_defs_conversion():
     """Test conversion of MCP tools with shared definitions ($defs)."""
     mcp_tools = [


### PR DESCRIPTION
Fixes #2393.

## Summary
- make MCP schema filtering tolerate non-dict schema values such as boolean additionalProperties
- add regression coverage for FastMCP-style schemas with additionalProperties: false

## Tests
- uv run --with pytest --with pytest-asyncio --with mcp pytest google/genai/tests/mcp/test_mcp_to_gemini_tools.py -q
- git diff --check