### PR TITLE
fix: support functools.partial objects as tools in t_tool()

### DIFF
--- a/google/genai/_transformers.py
+++ b/google/genai/_transformers.py
@@ -18,6 +18,7 @@
 import base64
 from collections.abc import Iterable, Mapping
 from enum import Enum, EnumMeta
+from functools import partial as _partial
 import inspect
 import io
 import logging
@@ -959,7 +960,7 @@ def t_tool(
 ) -> Optional[Union[types.Tool, Any]]:
   if not origin:
     return None
-  if inspect.isfunction(origin) or inspect.ismethod(origin):
+  if inspect.isfunction(origin) or inspect.ismethod(origin) or isinstance(origin, _partial):
     return types.Tool(
         function_declarations=[
             types.FunctionDeclaration.from_callable(


### PR DESCRIPTION
## Problem

Passing a `functools.partial` object in the `tools=` argument fails with a `400 INVALID_ARGUMENT` error from the API.

```python
import functools
from google import genai

def get_weather(city: str, unit: str = "celsius") -> str:
    ...

get_weather_fahrenheit = functools.partial(get_weather, unit="fahrenheit")

client = genai.Client(api_key="...")
# Raises 400 INVALID_ARGUMENT
client.models.generate_content(
    model="gemini-2.0-flash",
    contents="What is the weather in NYC?",
    config={"tools": [get_weather_fahrenheit]},
)
```

## Root cause

`t_tool()` in `google/genai/_transformers.py` checks for callables using `inspect.isfunction()` and `inspect.ismethod()`. Both return `False` for `functools.partial` objects even though they are fully callable. The partial slips through to the `else` branch which returns the raw object unchanged. The API receives something it cannot interpret and rejects the request.

## Fix

Add `isinstance(origin, functools.partial)` to the callable check so partial objects go through the same `FunctionDeclaration.from_callable()` path as regular functions and methods.

Fixes #907