### PR TITLE
fix: handle boolean additionalProperties in _filter_to_supported_schema

### DIFF
--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -127,6 +127,9 @@ def _filter_to_supported_schema(
     schema: _common.StringDict,
 ) -> _common.StringDict:
   """Filters the schema to only include fields that are supported by JSONSchema."""
+  if not isinstance(schema, dict):
+    return schema
+
   supported_fields: set[str] = set(types.JSONSchema.model_fields.keys())
 
   supported_fields.update([


### PR DESCRIPTION
## Summary
- Add `if not isinstance(schema, dict): return schema` guard at the top of `_filter_to_supported_schema()`
- Fixes `AttributeError: 'bool' object has no attribute 'items'` when MCP tools have `additionalProperties: false` in their JSON schema (common in Pydantic-generated schemas used by FastMCP)

Fixes #2393

## Test plan
- [x] Verified fix handles `additionalProperties: false` without crashing
- [x] Verified normal dict schemas still filter correctly
- [ ] Test with a real FastMCP server that produces boolean additionalProperties