### PR TITLE
fix: handle boolean MCP schema leaves

### DIFF
--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -24,7 +24,6 @@ from typing import Any
 import google.auth
 from google.auth.transport.requests import Request
 
-from . import _common
 from . import types
 from ._api_client import _MULTI_REGIONAL_LOCATIONS
 
@@ -124,9 +123,12 @@ def set_mcp_usage_header(headers: dict[str, str]) -> None:
 
 
 def _filter_to_supported_schema(
-    schema: _common.StringDict,
-) -> _common.StringDict:
+    schema: Any,
+) -> Any:
   """Filters the schema to only include fields that are supported by JSONSchema."""
+  if not isinstance(schema, dict):
+    return schema
+
   supported_fields: set[str] = set(types.JSONSchema.model_fields.keys())
 
   supported_fields.update([

--- a/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
+++ b/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
@@ -198,6 +198,45 @@ def test_properties_conversion():
   ]
 
 
+def test_additional_properties_boolean_conversion():
+  """Test conversion of MCP tools with boolean additionalProperties."""
+  mcp_tools = [
+      mcp_types.Tool(
+          name='tool',
+          description='tool-description',
+          inputSchema={
+              'type': 'object',
+              'properties': {
+                  'key1': {
+                      'type': 'object',
+                      'additionalProperties': False,
+                  },
+              },
+              'additionalProperties': False,
+          },
+      ),
+  ]
+
+  result = _mcp_utils.mcp_to_gemini_tools(mcp_tools)
+
+  assert result == [
+      types.Tool(
+          function_declarations=[
+              types.FunctionDeclaration(
+                  name='tool',
+                  description='tool-description',
+                  parameters=types.Schema(
+                      type='OBJECT',
+                      properties={
+                          'key1': types.Schema(type='OBJECT'),
+                      },
+                  ),
+              ),
+          ],
+      ),
+  ]
+
+
 def test_defs_conversion():
     """Test conversion of MCP tools with shared definitions ($defs)."""
     mcp_tools = [


### PR DESCRIPTION
## Root cause

MCP tool schemas can contain JSON Schema boolean leaves, such as `additionalProperties: false`. The MCP schema filter recursively processed `additionalProperties` as though every supported schema value were a mapping, so boolean leaves raised `AttributeError: 'bool' object has no attribute 'items'` before conversion.

## Change

Return non-dict schema leaves unchanged before iterating schema fields. This preserves valid JSON Schema boolean leaves through filtering so the downstream Schema conversion can handle or ignore them according to its supported surface.

Added a focused regression test covering top-level and nested `additionalProperties: false` in an MCP tool input schema.

## Validation

- `.venv/bin/python -m pytest google/genai/tests/mcp/test_mcp_to_gemini_tools.py -q` -> 11 passed

Note: a full `requirements.txt` install was not run to completion in this Python 3.14 environment because Pillow 11.0.0 attempted a source build and failed due missing JPEG headers. The relevant MCP test file was run with a minimal editable install plus `pytest`, `pytest-asyncio`, and `mcp`.