### PR TITLE
fix: account for operation polling timeout

### DIFF
--- a/google/genai/_transformers.py
+++ b/google/genai/_transformers.py
@@ -1186,7 +1186,7 @@ def t_resolve_operation(
           http_method='GET', path=name, request_dict={}
       )
       time.sleep(delay_seconds)
-      total_seconds += total_seconds
+      total_seconds += delay_seconds
       # Exponential backoff
       delay_seconds = min(
           delay_seconds * LRO_POLLING_MULTIPLIER,

--- a/google/genai/tests/transformers/test_t_operation.py
+++ b/google/genai/tests/transformers/test_t_operation.py
@@ -1,0 +1,58 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Tests for operation transformers."""
+
+from unittest import mock
+
+import pytest
+
+from ... import _transformers as t
+
+
+class _PendingOperationClient:
+
+  def __init__(self) -> None:
+    self.request_count = 0
+
+  def request(self, **kwargs):
+    self.request_count += 1
+    if self.request_count > 5:
+      raise AssertionError('operation polling did not time out')
+    return {
+        'name': 'projects/test/locations/us-central1/operations/123',
+        'done': False,
+    }
+
+
+def test_resolve_operation_times_out_for_pending_operation(monkeypatch):
+  client = _PendingOperationClient()
+
+  monkeypatch.setattr(t, 'LRO_POLLING_INITIAL_DELAY_SECONDS', 0.5)
+  monkeypatch.setattr(t, 'LRO_POLLING_MAXIMUM_DELAY_SECONDS', 0.5)
+  monkeypatch.setattr(t, 'LRO_POLLING_TIMEOUT_SECONDS', 1.0)
+
+  with mock.patch.object(t.time, 'sleep') as sleep_mock:
+    with pytest.raises(RuntimeError, match='timed out'):
+      t.t_resolve_operation(
+          client,
+          {
+              'name': 'projects/test/locations/us-central1/operations/123',
+              'done': False,
+          },
+      )
+
+  assert client.request_count == 3
+  sleep_mock.assert_has_calls([mock.call(0.5), mock.call(0.5), mock.call(0.5)])


### PR DESCRIPTION
## Summary

- Fix long-running operation polling timeout accounting so pending operations eventually raise after the configured timeout.
- Add a focused transformer unit test that catches the previous infinite-polling behavior without sleeping in real time.

## Why

`t_resolve_operation` initialized `total_seconds` to `0.0` but updated it with `total_seconds += total_seconds`, which leaves it at zero forever. If an operation never reaches `done: true`, the timeout guard never fires.

## Validation

- `.venv/bin/python -m pytest google/genai/tests/transformers/test_t_operation.py -q`
- `.venv/bin/python -m pytest google/genai/tests/transformers/test_t_*.py -q`
- `.venv/bin/python -m py_compile google/genai/_transformers.py google/genai/tests/transformers/test_t_operation.py`
- `git diff --check`

Note: `pytest google/genai/tests/transformers -q` could not collect in this local Python 3.14 environment because `google/genai/tests/transformers/test_blobs.py` imports `PIL`, and installing pinned `Pillow==11.0.0` from `requirements.txt` failed due missing JPEG headers/no compatible wheel in this image.
