### PR TITLE
fix: validate if value is dict before recursion in _filter_to_supported_schema

### DIFF
--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -143,7 +143,7 @@ def _filter_to_supported_schema(
 
   filtered_schema: dict[str, Any] = {}
   for field_name, field_value in schema.items():
-    if field_name in schema_field_names:
+    if field_name in schema_field_names and isinstance(field_value, dict):
       filtered_schema[field_name] = _filter_to_supported_schema(field_value)
     elif field_name in list_schema_field_names:
       filtered_schema[field_name] = [


### PR DESCRIPTION
Hey! 👋                            
                                                                                                                                                                                   
This is a fix for https://github.com/googleapis/python-genai/issues/2476.
                                                                                                                                                                           
What changed: Added an isinstance(field_value, dict) guard in _filter_to_supported_schema before recursing into schema_field_names entries (specifically additionalProperties).  
                                                                                                                                                                           
Why it crashed: The https://json-schema.org/understanding-json-schema/reference/object#additionalproperties allows additionalProperties to be either a boolean or a schema object. FastMCP (and other MCP SDKs) emit "additionalProperties": false by default, which triggered an AttributeError: 'bool' object has no attribute 'items'.
                                                                                                                                                                           
Testing: Verified against the repro script in the linked issue — old behavior is preserved for dict values, booleans now pass through correctly.                                 
                             
Happy to adjust if needed!                                                                                                                                     
Antoine     