### PR TITLE
fix: remove unsupported max_line_length arg from aiohttp readline()

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -447,9 +447,7 @@ class HttpResponse:
       try:
         while True:
           # Read a line from the stream. This returns bytes.
-          line_bytes = await self.response_stream.content.readline(
-              max_line_length=READ_BUFFER_SIZE
-          )
+          line_bytes = await self.response_stream.content.readline()
           if not line_bytes:
             break
           # Decode the bytes and remove trailing whitespace and newlines.


### PR DESCRIPTION
  Fixes #2487

  Regression introduced in #2437.

  **Problem:**
  `google-genai` 2.5.0 crashes when streaming with `aiohttp` installed:
  TypeError: StreamReader.readline() got an unexpected keyword argument 'max_line_length'

  **Root cause:**
  `aiohttp.StreamReader.readline()` does not accept any parameters. Its signature is:

  ```python
  async def readline(self) -> bytes:
      return await self.readuntil()

  The max_line_length keyword argument passed in _api_client.py is invalid for all released versions of aiohttp.

  Why this is safe: The line-length limit is already governed by the limit parameter of StreamReader, which is set correctly via read_bufsize=READ_BUFFER_SIZE when the aiohttp ClientSession is created.

  Change: Remove the unsupported max_line_length keyword argument from the readline() call.