### PR TITLE
docs: fix "to to" duplicate-word typo in _api_client docstrings

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -1007,7 +1007,7 @@ class BaseApiClient:
       Does not override the SSL context if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
         ctx: The SSL context to set.
 
       Returns:
@@ -1059,7 +1059,7 @@ class BaseApiClient:
       Does not override the SSL context if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
         ctx: The SSL context to set.
 
       Returns:
@@ -1117,7 +1117,7 @@ class BaseApiClient:
       Does not override the SSL context if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
         ctx: The SSL context to set.
 
       Returns:

--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -1119,7 +1119,7 @@ class BaseApiClient:
       Does not override the SSL context if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
         ctx: The SSL context to set.
 
       Returns:
@@ -1186,7 +1186,7 @@ class BaseApiClient:
       Does not override the SSL context if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
         ctx: The SSL context to set.
 
       Returns:
@@ -1257,7 +1257,7 @@ class BaseApiClient:
       Does not override the SSL context if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
         ctx: The SSL context to set.
 
       Returns:


### PR DESCRIPTION
## Summary

Three identical \`Args:\` docstrings in \`google/genai/_api_client.py\` (lines 1010, 1062, 1120) contain a duplicated \`to\`:

\`\`\`diff
-        args: The client args to to check for SSL context.
+        args: The client args to check for SSL context.
\`\`\`

Each instance is the docstring for a nested \`_maybe_set\` helper inside the three \`_ensure_*_ssl_ctx\` static methods on \`BaseApiClient\`. The three sibling \`options.async_client_args\` docstrings (lines 1038, etc.) already use the correct \"to check\", so this PR brings the nested ones into line.

Diff is exactly 3 lines, docstring-only — no runtime behaviour changes.

## Novelty check

\`gh search prs --repo googleapis/python-genai \"to to check\"\` returned no matches. No open PR touches these lines.