### PR TITLE
docs: fix incorrect pageSize() reference in Pager.page docstring

### DIFF
--- a/google/genai/pagers.py
+++ b/google/genai/pagers.py
@@ -77,7 +77,7 @@ class _BasePager(Generic[T]):
   def page(self) -> list[T]:
     """Returns a subset of the entire list of items.
 
-    For the number of items returned, see `pageSize()`.
+    For the number of items returned, see `page_size`.
 
     Usage:
 


### PR DESCRIPTION
The docstring for `_BasePager.page` references `pageSize()` (camelCase, as if it were a method), but the actual public attribute is the `page_size` property (snake_case, no parens).

This is purely a documentation fix — a one-line update in `google/genai/pagers.py` to point readers to the correct attribute name.