### PR TITLE
fix: keep responses for oversized JSON integers

### DIFF
--- a/google/genai/tests/models/test_generate_content.py
+++ b/google/genai/tests/models/test_generate_content.py
@@ -1058,6 +1058,31 @@ def test_json_schema_fields(client):
   assert response.parsed != None
 
 
+@pytest.mark.parametrize('schema_key', ['response_schema', 'response_json_schema'])
+def test_schema_parse_keeps_response_for_oversized_json_integer(
+    schema_key, use_vertex, replays_prefix, http_options
+):
+  get_int_max_str_digits = getattr(sys, 'get_int_max_str_digits', None)
+  if get_int_max_str_digits is None:
+    pytest.skip('Python runtime has no int string digit limit')
+  digit_limit = get_int_max_str_digits()
+  if digit_limit == 0:
+    pytest.skip('int string digit limit is disabled')
+
+  response_text = '{"count": ' + '1' * (digit_limit + 1) + '}'
+  response = types.GenerateContentResponse._from_response(
+      response={
+          'candidates': [
+              {'content': {'parts': [{'text': response_text}]}}
+          ],
+      },
+      kwargs={'config': {schema_key: {'type': 'object'}}},
+  )
+
+  assert response.text == response_text
+  assert response.parsed is None
+
+
 def test_pydantic_schema_orders_properties(client):
   class Restaurant(BaseModel):
     name: str

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -8264,7 +8264,7 @@ class GenerateContentResponse(_common.BaseModel):
       # may not be a valid json per stream response
       except pydantic.ValidationError:
         pass
-      except json.decoder.JSONDecodeError:
+      except ValueError:
         pass
     elif (
         isinstance(response_schema, EnumMeta) and result._get_text() is not None
@@ -8296,7 +8296,7 @@ class GenerateContentResponse(_common.BaseModel):
           parsed = {'placeholder': json.loads(result_text)}
           placeholder = Placeholder.model_validate(parsed)
           result.parsed = placeholder.placeholder
-      except json.decoder.JSONDecodeError:
+      except ValueError:
         pass
       except pydantic.ValidationError:
         pass
@@ -8312,7 +8312,7 @@ class GenerateContentResponse(_common.BaseModel):
         if result_text is not None:
           result.parsed = json.loads(result_text)
       # may not be a valid json per stream response
-      except json.decoder.JSONDecodeError:
+      except ValueError:
         pass
     elif typing.get_origin(response_schema) in _UNION_TYPES:
       # Union schema.
@@ -8329,7 +8329,7 @@ class GenerateContentResponse(_common.BaseModel):
               parsed = {'placeholder': json.loads(result_text)}
               placeholder = Placeholder.model_validate(parsed)
               result.parsed = placeholder.placeholder
-          except json.decoder.JSONDecodeError:
+          except ValueError:
             pass
           except pydantic.ValidationError:
             pass
@@ -8339,7 +8339,7 @@ class GenerateContentResponse(_common.BaseModel):
             if result_text is not None:
               result.parsed = json.loads(result_text)
           # may not be a valid json per stream response
-          except json.decoder.JSONDecodeError:
+          except ValueError:
             pass
 
     return result


### PR DESCRIPTION
## Summary

- catch `ValueError` in the response-schema parsing paths that already ignore invalid JSON
- keep the `GenerateContentResponse` object available when Python rejects a runaway integer literal via `int_max_str_digits`
- add a regression for both `response_schema` and `response_json_schema`

Fixes #2542.

## Verification

```bash
$env:PYTHONPATH='.'; $env:GOOGLE_GENAI_REPLAYS_DIRECTORY="$env:TEMP\google-genai-replays"; python -m pytest google\genai\tests\models\test_generate_content.py -k oversized_json_integer -q
python -m py_compile google\genai\types.py google\genai\tests\models\test_generate_content.py
python -m ruff check --select E9,F63,F7,F82 google\genai\types.py google\genai\tests\models\test_generate_content.py
git diff --check
```
