### PR TITLE
fix: accept grounding chunk metadata

### DIFF
--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -155,6 +155,30 @@ def test_factory_method_from_code_execution_result_part():
   assert isinstance(my_part, SubPart)
 
 
+def test_generate_content_response_accepts_grounding_chunk_metadata():
+  response = types.GenerateContentResponse.model_validate({
+      'candidates': [{
+          'content': {'parts': [{'text': 'ok'}], 'role': 'model'},
+          'groundingMetadata': {
+              'groundingChunks': [{
+                  'chunkMetadata': {'query': 'dummy_query'},
+                  'web': {
+                      'title': 'youtube.com',
+                      'uri': (
+                          'https://vertexaisearch.cloud.google.com/'
+                          'grounding-api-redirect/id'
+                      ),
+                  },
+              }]
+          },
+      }]
+  })
+
+  chunk = response.candidates[0].grounding_metadata.grounding_chunks[0]
+  assert chunk.chunk_metadata == {'query': 'dummy_query'}
+  assert chunk.web.title == 'youtube.com'
+
+
 def test_factory_method_from_mcp_call_tool_function_response_on_error():
   if not _is_mcp_imported:
     return

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -7146,6 +7146,10 @@ class GroundingChunk(_common.BaseModel):
   the source of the information.
   """
 
+  chunk_metadata: Optional[dict[str, Any]] = Field(
+      default=None,
+      description="""Metadata for this grounding chunk.""",
+  )
   image: Optional[GroundingChunkImage] = Field(
       default=None,
       description="""A grounding chunk from an image search result. See the `Image` message for details.""",
@@ -7175,6 +7179,9 @@ class GroundingChunkDict(TypedDict, total=False):
   is enabled, the model returns a `GroundingChunk` that contains a reference to
   the source of the information.
   """
+
+  chunk_metadata: Optional[dict[str, Any]]
+  """Metadata for this grounding chunk."""
 
   image: Optional[GroundingChunkImageDict]
   """A grounding chunk from an image search result. See the `Image` message for details."""


### PR DESCRIPTION
## Summary

Fixes #2510.

Some Vertex batch responses with Google Search grounding include `groundingMetadata.groundingChunks[].chunkMetadata`. The SDK currently rejects that payload because `GroundingChunk` forbids unknown fields and does not declare `chunk_metadata`.

This adds the field to both the model and TypedDict shape so the response can validate without dropping the metadata.

## Testing

```
python -m pytest google\genai\tests\types\test_types.py::test_generate_content_response_accepts_grounding_chunk_metadata -q
python -m pytest google\genai\tests\types\test_types.py -q
python -m py_compile google\genai\types.py google\genai\tests\types\test_types.py
git diff --check
```

I also ran `python -m pyink --check google\genai\types.py google\genai\tests\types\test_types.py`; it wants to reformat the existing generated/style-preserved files wholesale, so I did not apply it.
