### PR TITLE
fix: handle boolean MCP schema leaves

### DIFF
--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -24,7 +24,6 @@ from typing import Any
 import google.auth
 from google.auth.transport.requests import Request
 
-from . import _common
 from . import types
 from ._api_client import _MULTI_REGIONAL_LOCATIONS
 
@@ -124,9 +123,12 @@ def set_mcp_usage_header(headers: dict[str, str]) -> None:
 
 
 def _filter_to_supported_schema(
-    schema: _common.StringDict,
-) -> _common.StringDict:
+    schema: Any,
+) -> Any:
   """Filters the schema to only include fields that are supported by JSONSchema."""
+  if not isinstance(schema, dict):
+    return schema
+
   supported_fields: set[str] = set(types.JSONSchema.model_fields.keys())
 
   supported_fields.update([

--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -136,9 +136,12 @@ def set_mcp_usage_header(headers: dict[str, str]) -> None:
 
 
 def _filter_to_supported_schema(
-    schema: _common.StringDict,
-) -> _common.StringDict:
+    schema: Any,
+) -> Any:
   """Filters the schema to only include fields that are supported by JSONSchema."""
+  if not isinstance(schema, dict):
+    return schema
+
   supported_fields: set[str] = set(types.JSONSchema.model_fields.keys())
 
   supported_fields.update([

--- a/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
+++ b/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
@@ -285,6 +285,34 @@ def test_update_endpoint_labels_conversion():
     assert 'additionalProperties' in labels_schema
 
 
+def test_mcp_boolean_additional_properties_conversion():
+  """Test MCP schemas with boolean additionalProperties values."""
+  mcp_tools = [
+      mcp_types.Tool(
+          name='tool',
+          description='tool-description',
+          inputSchema={
+              'type': 'object',
+              'properties': {
+                  'payload': {
+                      'type': 'object',
+                      'additionalProperties': False,
+                  }
+              },
+          },
+      ),
+  ]
+
+  result = _mcp_utils.mcp_to_gemini_tools(mcp_tools)
+  payload_schema = (
+      result[0]
+      .function_declarations[0]
+      .parameters.properties['payload']
+  )
+
+  assert payload_schema.type == 'OBJECT'
+
+
 def test_agent_platform_preserves_unknown_fields():
     """Test that Agent Platform translation passes all schema fields directly
     to the backend.

--- a/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
+++ b/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
@@ -289,6 +289,34 @@ def test_update_endpoint_labels_conversion():
     assert 'additionalProperties' in labels_schema
 
 
+def test_mcp_boolean_additional_properties_conversion():
+  """Test MCP schemas with boolean additionalProperties values."""
+  mcp_tools = [
+      mcp_types.Tool(
+          name='tool',
+          description='tool-description',
+          inputSchema={
+              'type': 'object',
+              'properties': {
+                  'payload': {
+                      'type': 'object',
+                      'additionalProperties': False,
+                  }
+              },
+          },
+      ),
+  ]
+
+  result = _mcp_utils.mcp_to_gemini_tools(mcp_tools)
+  payload_schema = (
+      result[0]
+      .function_declarations[0]
+      .parameters.properties['payload']
+  )
+
+  assert payload_schema.type == 'OBJECT'
+
+
 def test_agent_platform_preserves_unknown_fields():
     """Test that Agent Platform translation passes all schema fields directly
     to the backend.


### PR DESCRIPTION
Fixes #2393.

`_filter_to_supported_schema()` recursively filters MCP JSON Schema input before converting it to a Gemini tool declaration. JSON Schema allows boolean values for `additionalProperties`, and FastMCP/Pydantic schemas commonly emit `additionalProperties: false`. The current recursion assumes every nested schema value is a dict and calls `.items()`, so those valid schemas crash with `AttributeError: 'bool' object has no attribute 'items'`.

This keeps scalar schema leaves as-is before recursing into dictionaries, then adds MCP conversion coverage for a nested object with `additionalProperties: false`.

## To verify

- `UNITTEST_ON_FORGE=1 python -m pytest google/genai/tests/mcp/test_mcp_to_gemini_tools.py -q`
- `python -m py_compile google/genai/_mcp_utils.py google/genai/tests/mcp/test_mcp_to_gemini_tools.py`
