### PR TITLE
docs: fix upload config display_name typo

### DIFF
--- a/google/genai/files.py
+++ b/google/genai/files.py
@@ -588,7 +588,7 @@ class Files(_api_module.BaseModule):
         binary mode. In other words, do not use non-blocking mode or text mode.
         The given stream must be seekable, that is, it must be able to call
         `seek()` on 'path'.
-      config: Optional parameters to set `diplay_name`, `mime_type`, and `name`.
+      config: Optional parameters to set `display_name`, `mime_type`, and `name`.
     """
     if self._api_client.vertexai:
       raise ValueError(
@@ -1207,7 +1207,7 @@ class AsyncFiles(_api_module.BaseModule):
         binary mode. In other words, do not use non-blocking mode or text mode.
         The given stream must be seekable, that is, it must be able to call
         `seek()` on 'path'.
-      config: Optional parameters to set `diplay_name`, `mime_type`, and `name`.
+      config: Optional parameters to set `display_name`, `mime_type`, and `name`.
     """
     if self._api_client.vertexai:
       raise ValueError(


### PR DESCRIPTION
Fixes googleapis/python-genai#2599.

## Summary
- Correct `diplay_name` to `display_name` in the sync and async file upload config docstrings.

## Testing
- `git diff --check`
- `rg -n 'diplay_name|display_name' google/genai/files.py`