### PR TITLE
fix: preserve explicit false SSL options

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -1038,13 +1038,11 @@ class BaseApiClient:
     verify = 'verify'
     args = options.client_args
     async_args = options.async_client_args
-    ctx = (
-        args.get(verify)
-        if args
-        else None or async_args.get(verify)
-        if async_args
-        else None
-    )
+    ctx = None
+    if args and args.get(verify) is not None:
+      ctx = args[verify]
+    elif async_args and async_args.get(verify) is not None:
+      ctx = async_args[verify]
 
     if ctx is None:
       # Initialize the SSL context for the httpx client.
@@ -1067,21 +1065,21 @@ class BaseApiClient:
 
     def _maybe_set(
         args: Optional[_common.StringDict],
-        ctx: ssl.SSLContext,
+        ctx: Any,
     ) -> _common.StringDict:
-      """Sets the SSL context in the client args if not set.
+      """Sets the SSL option in the client args if not set.
 
-      Does not override the SSL context if it is already set.
+      Does not override the SSL option if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
-        ctx: The SSL context to set.
+        args: The client args to to check for SSL option.
+        ctx: The SSL option to set.
 
       Returns:
-        The client args with the SSL context included.
+        The client args with the SSL option included.
       """
       args = (args or {}).copy()
-      if not args.get(verify):
+      if args.get(verify) is None:
         args[verify] = ctx
       if 'timeout' not in args:
         args['timeout'] = None
@@ -1134,21 +1132,21 @@ class BaseApiClient:
 
     def _maybe_set(
         args: Optional[_common.StringDict],
-        ctx: ssl.SSLContext,
+        ctx: Any,
     ) -> _common.StringDict:
-      """Sets the SSL context in the client args if not set.
+      """Sets the SSL option in the client args if not set.
 
-      Does not override the SSL context if it is already set.
+      Does not override the SSL option if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
-        ctx: The SSL context to set.
+        args: The client args to to check for SSL option.
+        ctx: The SSL option to set.
 
       Returns:
-        The client args with the SSL context included.
+        The client args with the SSL option included.
       """
-      if not args or not args.get(verify):
-        args = (args or {}).copy()
+      args = (args or {}).copy()
+      if args.get(verify) is None:
         args[verify] = ctx
       # Drop the args that isn't in the aiohttp RequestOptions.
       copied_args = args.copy()
@@ -1205,21 +1203,21 @@ class BaseApiClient:
 
     def _maybe_set(
         args: Optional[_common.StringDict],
-        ctx: ssl.SSLContext,
+        ctx: Any,
     ) -> _common.StringDict:
-      """Sets the SSL context in the client args if not set.
+      """Sets the SSL option in the client args if not set.
 
-      Does not override the SSL context if it is already set.
+      Does not override the SSL option if it is already set.
 
       Args:
-        args: The client args to to check for SSL context.
-        ctx: The SSL context to set.
+        args: The client args to to check for SSL option.
+        ctx: The SSL option to set.
 
       Returns:
-        The client args with the SSL context included.
+        The client args with the SSL option included.
       """
-      if not args or not args.get(verify):
-        args = (args or {}).copy()
+      args = (args or {}).copy()
+      if args.get(verify) is None:
         args[verify] = ctx
       # Drop the args that isn't in the aiohttp RequestOptions.
       copied_args = args.copy()

--- a/google/genai/tests/client/test_client_initialization.py
+++ b/google/genai/tests/client/test_client_initialization.py
@@ -1170,6 +1170,42 @@ def test_client_ssl_context_explicit_initialization_async_args():
     assert isinstance(async_client_args["verify"], ssl.SSLContext)
 
 
+@pytest.mark.parametrize(
+    "options",
+    [
+        types.HttpOptions(client_args={"verify": False}),
+        types.HttpOptions(async_client_args={"verify": False}),
+        types.HttpOptions(
+            client_args={"verify": False},
+            async_client_args={"verify": False},
+        ),
+    ],
+)
+def test_client_ssl_context_preserves_explicit_false_httpx_verify(options):
+  client_args, async_client_args = (
+      api_client.BaseApiClient._ensure_httpx_ssl_ctx(options)
+  )
+
+  assert client_args["verify"] is False
+  assert async_client_args["verify"] is False
+
+
+def test_client_ssl_context_preserves_explicit_false_aiohttp_ssl():
+  options = types.HttpOptions(async_client_args={"ssl": False})
+
+  async_client_args = api_client.BaseApiClient._ensure_aiohttp_ssl_ctx(options)
+
+  assert async_client_args["ssl"] is False
+
+
+def test_client_ssl_context_preserves_explicit_false_websocket_ssl():
+  options = types.HttpOptions(async_client_args={"ssl": False})
+
+  async_client_args = api_client.BaseApiClient._ensure_websocket_ssl_ctx(options)
+
+  assert async_client_args["ssl"] is False
+
+
 def test_constructor_with_base_url_from_http_options():
   mldev_http_options = {
       "base_url": "https://placeholder-fake-url.com/",


### PR DESCRIPTION
Fixes #2557.

## Summary
- preserve explicit falsy SSL options instead of treating them as missing
- keep `client_args={"verify": False}` / `async_client_args={"verify": False}` as `False` for httpx
- keep `async_client_args={"ssl": False}` as `False` for aiohttp and websocket paths
- add regression coverage for the explicit `False` cases

## Root cause
The SSL helpers used truthiness checks such as `if not ctx` and `if not args.get(...)`. That makes an explicit `False` indistinguishable from an unset option, so the SDK replaced the user's disabled-verification setting with a default `ssl.SSLContext`.

## Validation
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy .venv/bin/python -m pytest google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_implicit_initialization google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_explicit_initialization_same_args google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_explicit_initialization_separate_args google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_explicit_initialization_sync_args google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_explicit_initialization_async_args google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_preserves_explicit_false_httpx_verify google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_preserves_explicit_false_aiohttp_ssl google/genai/tests/client/test_client_initialization.py::test_client_ssl_context_preserves_explicit_false_websocket_ssl -q` (`10 passed`)
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy .venv/bin/python -m pytest google/genai/tests/client/test_client_initialization.py -q` (`90 passed`)
- `git diff --check`
