### PR TITLE
[codex] Preserve boolean additionalProperties schemas

### DIFF
--- a/google/genai/_mcp_utils.py
+++ b/google/genai/_mcp_utils.py
@@ -21,9 +21,6 @@ from importlib.metadata import PackageNotFoundError, version
 import typing
 from typing import Any
 
-import google.auth
-from google.auth.transport.requests import Request
-
 from . import _common
 from . import types
 from ._api_client import _MULTI_REGIONAL_LOCATIONS
@@ -144,7 +141,11 @@ def _filter_to_supported_schema(
   filtered_schema: dict[str, Any] = {}
   for field_name, field_value in schema.items():
     if field_name in schema_field_names:
-      filtered_schema[field_name] = _filter_to_supported_schema(field_value)
+      filtered_schema[field_name] = (
+          _filter_to_supported_schema(field_value)
+          if isinstance(field_value, dict)
+          else field_value
+      )
     elif field_name in list_schema_field_names:
       filtered_schema[field_name] = [
           _filter_to_supported_schema(value) for value in field_value

--- a/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
+++ b/google/genai/tests/mcp/test_mcp_to_gemini_tools.py
@@ -285,6 +285,28 @@ def test_update_endpoint_labels_conversion():
     assert 'additionalProperties' in labels_schema
 
 
+def test_additional_properties_boolean_conversion():
+    """Test boolean additionalProperties schemas are preserved."""
+
+    mcp_tools = [
+        mcp_types.Tool(
+            name='test_func',
+            description='Test function.',
+            inputSchema={
+                'type': 'object',
+                'properties': {
+                    'arg1': {'type': 'string'},
+                },
+                'additionalProperties': False,
+            },
+        ),
+    ]
+    result = _mcp_utils.mcp_to_gemini_tools(mcp_tools, is_agent_platform=True)
+    schema = result[0].function_declarations[0].parameters_json_schema
+
+    assert schema['additionalProperties'] is False
+
+
 def test_agent_platform_preserves_unknown_fields():
     """Test that Agent Platform translation passes all schema fields directly
     to the backend.


### PR DESCRIPTION
## Summary
- preserve boolean JSON Schema values for `additionalProperties` / schema-like fields when filtering MCP schemas
- keep nested schema dicts recursively filtered as before
- add regression coverage for `additionalProperties: false` through `mcp_to_gemini_tools`

Fixes #2476.

## Root cause
`_filter_to_supported_schema` treated `additionalProperties` as a nested schema unconditionally. JSON Schema also allows boolean schemas there, so `additionalProperties: false` was passed into `_filter_to_supported_schema` and crashed with `AttributeError: bool object has no attribute items`.

## Validation
- Reproduced the pre-fix crash with `_filter_to_supported_schema({"type": "object", "properties": {"arg1": {"type": "string"}}, "additionalProperties": False})`
- `uv run python - <<'PY' ... _filter_to_supported_schema(...) ... PY` -> preserves `additionalProperties: False`
- `uv run --with pytest --with pytest-asyncio --with mcp pytest google/genai/tests/mcp/test_mcp_to_gemini_tools.py::test_additional_properties_boolean_conversion -q` -> 1 passed
- `env -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u http_proxy -u https_proxy -u all_proxy uv run --with pytest --with pytest-asyncio --with mcp pytest google/genai/tests/mcp/test_mcp_to_gemini_tools.py -q` -> 11 passed
- `uv run python -m py_compile google/genai/_mcp_utils.py google/genai/tests/mcp/test_mcp_to_gemini_tools.py` -> passed

Note: `uv run --with mypy --with pytest --with pytest-asyncio --with mcp mypy google/genai/_mcp_utils.py` is currently blocked by existing type errors in `google/genai/types.py` and `google/genai/_api_client.py`, not by this diff.