### PR TITLE
fix: honor field defaults in nested Pydantic model function schemas

### DIFF
--- a/google/genai/_automatic_function_calling_util.py
+++ b/google/genai/_automatic_function_calling_util.py
@@ -301,13 +301,21 @@ def _parse_schema_from_parameter(  # type: ignore[return]
     schema.type = _py_builtin_type_to_schema_type[dict]
     schema.properties = {}
     for field_name, field_info in param.annotation.model_fields.items():
+      field_param = inspect.Parameter(
+          field_name,
+          inspect.Parameter.POSITIONAL_OR_KEYWORD,
+          annotation=field_info.annotation,
+      )
+      # Forward the field's default so fields with a default are not marked
+      # required. Without this the sub-schema default stays unset and every
+      # non-Optional field is treated as required.
+      if not field_info.is_required():
+        field_param = field_param.replace(
+            default=field_info.get_default(call_default_factory=True)
+        )
       schema.properties[field_name] = _parse_schema_from_parameter(
           api_option,
-          inspect.Parameter(
-              field_name,
-              inspect.Parameter.POSITIONAL_OR_KEYWORD,
-              annotation=field_info.annotation,
-          ),
+          field_param,
           func_name,
       )
     schema.required = _get_required_fields(schema)

--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -1514,6 +1514,55 @@ def test_pydantic_model_in_list_type():
   assert actual_schema_vertex == expected_schema
 
 
+def test_pydantic_model_with_default_fields():
+  class MyPydanticModel(pydantic.BaseModel):
+    a: int
+    b: int = 5
+    c: str = 'hello'
+    d: list[int] = pydantic.Field(default_factory=list)
+
+  def func_under_test(
+      a: MyPydanticModel,
+  ):
+    """test pydantic model with default fields."""
+    pass
+
+  expected_schema = types.FunctionDeclaration(
+      name='func_under_test',
+      parameters=types.Schema(
+          type='OBJECT',
+          properties={
+              'a': types.Schema(
+                  type='OBJECT',
+                  properties={
+                      'a': types.Schema(type='INTEGER'),
+                      'b': types.Schema(type='INTEGER', default=5),
+                      'c': types.Schema(type='STRING', default='hello'),
+                      'd': types.Schema(
+                          type='ARRAY',
+                          default=[],
+                          items=types.Schema(type='INTEGER'),
+                      ),
+                  },
+                  required=['a'],
+              ),
+          },
+          required=['a'],
+      ),
+      description='test pydantic model with default fields.',
+  )
+
+  actual_schema_mldev = types.FunctionDeclaration.from_callable(
+      client=mldev_client, callable=func_under_test
+  )
+  actual_schema_vertex = types.FunctionDeclaration.from_callable(
+      client=vertex_client, callable=func_under_test
+  )
+
+  assert actual_schema_mldev == expected_schema
+  assert actual_schema_vertex == expected_schema
+
+
 @pytest.mark.skip(
     reason=(
         'AFC is in progress of refactoring, this test is failing python 3.14'


### PR DESCRIPTION
## Summary

When automatic function calling generates a schema for a parameter that is a Pydantic model, sub-fields that have a default are incorrectly marked as **required**. This forces the model to supply values for parameters that should be optional.

```python
import pydantic
from google.genai import types

class Foo(pydantic.BaseModel):
    a: int              # required
    b: int = 5          # has a default -> should be optional
    c: str = 'hello'    # has a default -> should be optional

def fn(foo: Foo): ...

decl = types.FunctionDeclaration.from_callable(client=client, callable=fn)
# decl.parameters.properties['foo'].required == ['a', 'b', 'c']   # BUG
# expected                                    == ['a']
```

## Root cause

In `_automatic_function_calling_util._parse_schema_from_parameter`, the Pydantic-model branch builds each sub-field via `inspect.Parameter(field_name, ..., annotation=field_info.annotation)` but never passes `field_info.default`. The recursive call therefore sees no default, the sub-schema's `default` stays `None`, and `_get_required_fields` (`not nullable and default is None`) lists the field as required. Top-level parameters already work because their defaults flow through `param.default`; only nested-model fields were affected.

## Fix

Forward each field's default into the sub-field `inspect.Parameter`, resolving `default_factory` via `field_info.get_default(call_default_factory=True)`, and only when the field is not required. This leaves `Optional`-without-default fields (already handled via `nullable`) untouched and does not modify the shared `_get_required_fields` helper.

Verified across concrete defaults (`b=5`), factory defaults (`d: list = Field(default_factory=list)`), falsy defaults (`f: int = 0`), and `Optional[int]` without a default — only genuinely-required fields remain in `required`.

## Testing

Added `test_pydantic_model_with_default_fields` to `google/genai/tests/types/test_types.py` (fails on main, passes with the fix). Existing schema/callable tests unchanged:

```
pytest google/genai/tests/types/test_types.py -k 'pydantic or default_value or built_in'   # 22 passed
pytest google/genai/tests/afc/ google/genai/tests/transformers/test_t_tool.py test_t_tools.py  # 122 passed
```
(2 pre-existing ReplayApiClient fixture errors in afc_thoughts are unrelated — they fail identically on clean main.)

This change was developed with AI assistance; I verified the root cause and behavior against the cited code paths, reviewed every line, and ran the tests above.