### PR TITLE
perf: defer building model validators until first use

### DIFF
--- a/google/genai/_common.py
+++ b/google/genai/_common.py
@@ -559,6 +559,10 @@ class BaseModel(pydantic.BaseModel):
       ser_json_bytes='base64',
       val_json_bytes='base64',
       ignored_types=(typing.TypeVar,),
+      # Most of the ~770 models defined in `types` are never used by any single
+      # application, so build each model's validator and serializer the first time
+      # the model is actually used rather than when `google.genai` is imported.
+      defer_build=True,
   )
 
   @pydantic.model_validator(mode='before')


### PR DESCRIPTION
Adds `defer_build=True` to the `model_config` of `google.genai._common.BaseModel`, so that each model's pydantic validator and serializer is built the first time the model is actually used rather than when `google.genai` is imported.

`google.genai.types` defines 424 pydantic models (each with a `TypedDict` mirror), 418 of which get a validator *and* a serializer built at import time today. Any single application uses a small fraction of them — a client doing text generation never touches the Live, Batch, Tuning or Caching families.

### Measurements

macOS/arm64, `google-genai` 1.72.0, released `pydantic` 2.13.4 / `pydantic-core` 2.46.4 from PyPI, no pydantic plugins installed. RSS attributable to `import google.genai`, measured in-process as an `ru_maxrss` delta; fresh interpreter per sample, warm bytecode caches, both variants interleaved round-robin, median of 12 samples each:

| Python | | import RSS | import time |
| --- | --- | --- | --- |
| 3.12 | today | 56.0 MB | 398 ms |
| 3.12 | `defer_build=True` | **49.3 MB** | **287 ms** |
| | | −6.6 MB (−11.9%) | −111 ms (−27.8%) |
| 3.14 | today | 63.4 MB | 390 ms |
| 3.14 | `defer_build=True` | **57.0 MB** | **298 ms** |
| | | −6.3 MB (−10.0%) | −92 ms (−23.6%) |

The deferred work comes back only for the models actually used, once each (Python 3.12):

| | today | `defer_build=True` |
| --- | --- | --- |
| first `types.Part(...)` | 0.04 ms | 2.3 ms |
| first `types.Content(...)` + `types.GenerateContentConfig(...)` | 0.04 ms | 11.0 ms |
| steady-state `types.Part(...)` | 3.33 µs | 3.26 µs |
| steady-state `content.model_dump(exclude_none=True)` | 1.15 µs | 1.14 µs |
| RSS after exercising all of the above | 56.1 MB | 50.9 MB |

So an application pays roughly 13 ms once, at first use, for the model families it actually touches, and keeps most of the memory saving permanently. Validation and serialization throughput are unaffected — `defer_build` only moves *when* the validator is built, not what it does.

### Compatibility

`defer_build` is a standard pydantic `ConfigDict` option, available since pydantic 2.1 (this package requires ≥ 2.9), and it is inherited by every `BaseModel` subclass in `types.py`. `model_validate`, `model_dump` and `model_json_schema` all trigger the build transparently on first use; `__pydantic_core_schema__` is regenerated on demand if anything asks for it.

The full test suite passes with the change.
