### PR TITLE
fix: reject unsupported response schemas on Vertex AI

### DIFF
--- a/google/genai/_transformers.py
+++ b/google/genai/_transformers.py
@@ -643,15 +643,13 @@ def _raise_for_unsupported_schema_type(origin: Any) -> None:
 def _raise_for_unsupported_mldev_properties(
     schema: Any, client: Optional[_api_client.BaseApiClient]
 ) -> None:
-  if (
-      client
-      and not client.vertexai
-      and (
-          schema.get('additionalProperties')
-          or schema.get('additional_properties')
-      )
+  if client and (
+      schema.get('additionalProperties') or schema.get('additional_properties')
   ):
-    raise ValueError('additionalProperties is only supported in Gemini Enterprise Agent Platform mode, , not in Gemini Developer API mode.')
+    raise ValueError(
+        'additionalProperties is only supported in Gemini Enterprise Agent '
+        'Platform mode, not in Gemini Developer API or Vertex AI mode.'
+    )
 
 
 def process_schema(

--- a/google/genai/tests/transformers/test_schema.py
+++ b/google/genai/tests/transformers/test_schema.py
@@ -532,34 +532,11 @@ def test_process_schema_order_properties_propagates_into_additional_properties(
           },
       },
   }
-  schema_without_property_ordering = copy.deepcopy(schema)
-  schema_with_property_ordering = {
-      'type': 'OBJECT',
-      'additionalProperties': {
-          'type': 'OBJECT',
-          'properties': {
-              'foo': {'type': 'STRING'},
-              'bar': {'type': 'STRING'},
-          },
-          'property_ordering': ['foo', 'bar'],
-      },
-  }
-
-  if client.vertexai:
+  with pytest.raises(ValueError) as e:
     _transformers.process_schema(
         schema, client, order_properties=order_properties
     )
-
-    if order_properties:
-      assert schema == schema_with_property_ordering
-    else:
-      assert schema == schema_without_property_ordering
-  else:
-    with pytest.raises(ValueError) as e:
-      _transformers.process_schema(
-          schema, client, order_properties=order_properties
-      )
-    assert 'additionalProperties is only supported in Gemini Enterprise Agent Platform mode' in str(e)
+  assert 'additionalProperties is only supported in Gemini Enterprise Agent Platform mode' in str(e.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #2889

Vertex AI structured output does not support arbitrary `additionalProperties` response schemas, but the client previously allowed them and could return empty dictionaries at runtime. Reject these schemas before sending the request, with an error that identifies the supported mode.

Validation:
- `python3 -m compileall -q google/genai`
- `git diff --check`
- The targeted pytest could not run locally because the environment is missing `google.auth`.