### PR TITLE
Retry Google Auth transport failures

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -577,7 +577,7 @@ def retry_args(options: Optional[HttpRetryOptions]) -> _common.StringDict:
   retriable_codes = options.http_status_codes or _RETRY_HTTP_STATUS_CODES
   retry = tenacity.retry_if_exception(
       lambda e: (isinstance(e, errors.APIError) and e.code in retriable_codes)
-      or isinstance(e, _HTTPX_TRANSIENT_EXC),
+      or isinstance(e, _HTTPX_TRANSIENT_EXC + (auth_exceptions.TransportError,)),
   )
   wait = tenacity.wait_exponential_jitter(
       initial=options.initial_delay or _RETRY_INITIAL_DELAY,

--- a/google/genai/tests/client/test_retries.py
+++ b/google/genai/tests/client/test_retries.py
@@ -19,6 +19,8 @@ import asyncio
 from collections.abc import Sequence
 import datetime
 from unittest import mock
+
+from google.auth import exceptions as auth_exceptions
 import pytest
 
 try:
@@ -202,6 +204,12 @@ def test_retry_args_retries_httpx_transport_errors():
   # Unrelated transport errors are not retried.
   assert not retry.predicate(httpx.InvalidURL('bad url'))
   assert not retry.predicate(ValueError('not a transport error'))
+
+
+def test_retry_args_retries_google_auth_transport_errors():
+  args = api_client.retry_args(types.HttpRetryOptions())
+  assert args['retry'].predicate(auth_exceptions.TransportError('refresh failed'))
+  assert not args['retry'].predicate(auth_exceptions.RefreshError('invalid credentials'))
 
 
 def _patch_auth_default():


### PR DESCRIPTION
Fixes #2869\n\nSummary:\n- Treat Google Auth TransportError as transient when HttpRetryOptions is enabled.\n- Keep permanent RefreshError failures non-retryable.\n- Add retry predicate coverage.\n\nTests:\n- Python syntax compilation passed.\n- Pytest could not start because the google-auth dependency is unavailable.