### PR TITLE
Restore audio transcription mode configuration

### DIFF
--- a/google/genai/tests/types/test_types.py
+++ b/google/genai/tests/types/test_types.py
@@ -46,6 +46,13 @@ class SubFunctionResponsePart(types.FunctionResponsePart):
   pass
 
 
+def test_audio_transcription_config_mode():
+  config = types.AudioTranscriptionConfig(mode='smart')
+
+  assert config.mode == types.AudioTranscriptionConfigMode.SMART
+  assert config.model_dump(by_alias=True, exclude_none=True)['mode'] == 'SMART'
+
+
 def test_factory_method_from_uri_part():
 
   my_part = SubPart.from_uri(
@@ -2969,4 +2976,3 @@ def test_computer_use_types():
   assert c.enable_prompt_injection_detection is True
   assert len(c.disabled_safety_policies) == 2
   assert types.SafetyPolicy.FINANCIAL_TRANSACTIONS in c.disabled_safety_policies
-

--- a/google/genai/types.py
+++ b/google/genai/types.py
@@ -6338,6 +6338,15 @@ class LanguageHintsDict(TypedDict, total=False):
 LanguageHintsOrDict = Union[LanguageHints, LanguageHintsDict]
 
 
+class AudioTranscriptionConfigMode(_common.CaseInSensitiveEnum):
+  """Controls the level of detail returned by audio transcription."""
+
+  VERBATIM = 'VERBATIM'
+  """Returns a verbatim transcription."""
+  SMART = 'SMART'
+  """Returns a cleaned-up transcription."""
+
+
 class AudioTranscriptionConfig(_common.BaseModel):
   """The audio transcription configuration in Setup."""
 
@@ -6371,6 +6380,10 @@ class AudioTranscriptionConfig(_common.BaseModel):
       description="""Configures speaker diarization.
       """,
   )
+  mode: Optional[AudioTranscriptionConfigMode] = Field(
+      default=None,
+      description="""Controls the level of detail returned by audio transcription.""",
+  )
 
 
 class AudioTranscriptionConfigDict(TypedDict, total=False):
@@ -6398,6 +6411,9 @@ class AudioTranscriptionConfigDict(TypedDict, total=False):
   diarization: Optional[bool]
   """Configures speaker diarization.
       """
+
+  mode: Optional[AudioTranscriptionConfigMode]
+  """Controls the level of detail returned by audio transcription."""
 
 
 AudioTranscriptionConfigOrDict = Union[


### PR DESCRIPTION
Fixes #2892.\n\nRestore AudioTranscriptionConfigMode with VERBATIM and SMART values and expose the mode field on both the Pydantic model and its TypedDict counterpart. This lets callers use the modes advertised for Live audio transcription and preserves the generated wire field.\n\nAdded a model serialization regression test.\n\nValidation: python3 -m py_compile passed. The targeted pytest could not be collected locally because google-auth is not installed.