### PR TITLE
fix(api_client): explicitly close connections and clear large response buffers to prevent memory leaks

### DIFF
--- a/google/genai/_api_client.py
+++ b/google/genai/_api_client.py
@@ -1509,8 +1509,20 @@ class BaseApiClient:
       )
       response = self._httpx_client.send(httpx_request, stream=stream)  # type: ignore[union-attr, arg-type]
     errors.APIError.raise_for_response(response)
+    if stream:
+      return HttpResponse(response.headers, response)
+    
+    text = response.text
+    # Eagerly release memory to prevent unbounded growth (Issue #2369)
+    if hasattr(response, "close"):
+      response.close()
+    if hasattr(response, "_content"):
+      response._content = b""
+    if hasattr(response, "_text"):
+      response._text = ""
+      
     return HttpResponse(
-        response.headers, response if stream else [response.text]
+        response.headers, [text]
     )
 
   def _request(
@@ -1656,8 +1668,14 @@ class BaseApiClient:
           if hasattr(unwrapped_response, '_response'):
             unwrapped_response = unwrapped_response._response
 
+          text = await unwrapped_response.text()
+          if hasattr(unwrapped_response, 'release'):
+            unwrapped_response.release()
+          if hasattr(unwrapped_response, '_body'):
+            unwrapped_response._body = None
+
           return HttpResponse(
-              unwrapped_response.headers, [await unwrapped_response.text()]
+              unwrapped_response.headers, [text]
           )
         except (
             aiohttp.ClientConnectorError,
@@ -1690,9 +1708,15 @@ class BaseApiClient:
           if hasattr(unwrapped_retry_response, '_response'):
             unwrapped_retry_response = unwrapped_retry_response._response
 
+          text = await unwrapped_retry_response.text()
+          if hasattr(unwrapped_retry_response, 'release'):
+            unwrapped_retry_response.release()
+          if hasattr(unwrapped_retry_response, '_body'):
+            unwrapped_retry_response._body = None
+
           return HttpResponse(
               unwrapped_retry_response.headers,
-              [await unwrapped_retry_response.text()],
+              [text],
           )
       else:
         # aiohttp is not available. Fall back to httpx.
@@ -1704,7 +1728,17 @@ class BaseApiClient:
             timeout=http_request.timeout,
         )
         await errors.APIError.raise_for_async_response(client_response)
-        return HttpResponse(client_response.headers, [client_response.text])
+        
+        text = client_response.text
+        # Eagerly release memory to prevent unbounded growth (Issue #2369)
+        if hasattr(client_response, "aclose"):
+          await client_response.aclose()
+        if hasattr(client_response, "_content"):
+          client_response._content = b""
+        if hasattr(client_response, "_text"):
+          client_response._text = ""
+
+        return HttpResponse(client_response.headers, [text])
 
   async def _async_request(
       self,


### PR DESCRIPTION
## Description
When running multiple async generation requests, the `google-genai` SDK leaks memory. The underlying `httpx` or `aiohttp` response objects accumulate in memory because they are not explicitly closed after the text is read. This causes unbounded memory growth over time.

## Fix implemented
I modified `google/genai/_api_client.py` to eagerly release network resources. For non streaming responses, as soon as `response.text()` is read, the patch explicitly calls `close()` or `release()` on the response object and clears out the internal `_content` buffers. 

## Steps to Reproduce
Run a loop doing `await client.aio.models.generate_content(...)`. Check `tracemalloc`. You will see `httpx.Response` and raw bytes accumulating in memory. After this patch, memory stays flat.